### PR TITLE
Fix non-working configuration page caused by null pixel object

### DIFF
--- a/classes/API/FacebookClient.php
+++ b/classes/API/FacebookClient.php
@@ -64,13 +64,10 @@ class FacebookClient
     public function getPixel($pixelId)
     {
         $responseContent = $this->get((int) $pixelId, ['name', 'last_fired_time', 'is_unavailable']);
-        if (!$responseContent) {
-            return null;
-        }
 
         return new Pixel(
             isset($responseContent['name']) ? $responseContent['name'] : null,
-            isset($responseContent['id']) ? $responseContent['id'] : null,
+            isset($responseContent['id']) ? $responseContent['id'] : $pixelId,
             isset($responseContent['last_fired_time']) ? $responseContent['last_fired_time'] : null,
             isset($responseContent['is_unavailable']) ? !$responseContent['is_unavailable'] : false
         );


### PR DESCRIPTION
I get a 403 Forbidden with my account when I try to get Pixel details from facebook, preventing the configuration page to be displayed

![image](https://user-images.githubusercontent.com/6768917/97199636-22292b00-17a8-11eb-86f4-596a5e5280fb.png)

This PR allow a class to be created anyway, so I can read my ID, switch the feature and still reach my Pixel page