### PR TITLE
Do not filter anymore letters in zipcode

### DIFF
--- a/classes/Utility/CustomerInformationUtility.php
+++ b/classes/Utility/CustomerInformationUtility.php
@@ -15,10 +15,7 @@ class CustomerInformationUtility
             $address = reset($simpleAddresses);
             $arrayReturned['city'] = $address['city'] ? strtolower($address['city']) : null;
             $arrayReturned['countryIso'] = $address['country_iso'] ? strtolower($address['country_iso']) : null;
-
-            $arrayReturned['postCode'] = $address['postcode'] ?
-                preg_replace('/[^0-9.]+/', '', $address['postcode'])
-                : null;
+            $arrayReturned['postCode'] = $address['postcode'] ? strtolower($address['postcode']) : null;
 
             $arrayReturned['phone'] = $address['phone'] ?
                 preg_replace('/[^0-9.]+/', '', $address['phone'])


### PR DESCRIPTION
Following last call with Facebook, we remove the filter on the zipcode, as it actually allows letters.