### PR TITLE
Take boolean in account from configuration table

### DIFF
--- a/classes/API/FacebookClient.php
+++ b/classes/API/FacebookClient.php
@@ -86,7 +86,7 @@ class FacebookClient
             isset($responseContent['id']) ? $responseContent['id'] : $pixelId,
             isset($responseContent['last_fired_time']) ? $responseContent['last_fired_time'] : null,
             isset($responseContent['is_unavailable']) ? !$responseContent['is_unavailable'] : false,
-            $this->configurationAdapter->get(Config::PS_FACEBOOK_PIXEL_ENABLED)
+            (bool) $this->configurationAdapter->get(Config::PS_FACEBOOK_PIXEL_ENABLED)
         );
     }
 

--- a/classes/Dispatcher/EventDispatcher.php
+++ b/classes/Dispatcher/EventDispatcher.php
@@ -2,6 +2,7 @@
 
 namespace PrestaShop\Module\PrestashopFacebook\Dispatcher;
 
+use PrestaShop\Module\PrestashopFacebook\Adapter\ConfigurationAdapter;
 use PrestaShop\Module\PrestashopFacebook\Config\Config;
 use PrestaShop\Module\PrestashopFacebook\Handler\ApiConversionHandler;
 use PrestaShop\Module\PrestashopFacebook\Handler\PixelHandler;
@@ -18,10 +19,16 @@ class EventDispatcher
      */
     private $pixelHandler;
 
-    public function __construct(ApiConversionHandler $apiConversionHandler, PixelHandler $pixelHandler)
+    /**
+     * @var ConfigurationAdapter
+     */
+    private $configurationAdapter;
+
+    public function __construct(ApiConversionHandler $apiConversionHandler, PixelHandler $pixelHandler, ConfigurationAdapter $configurationAdapter)
     {
         $this->conversionHandler = $apiConversionHandler;
         $this->pixelHandler = $pixelHandler;
+        $this->configurationAdapter = $configurationAdapter;
     }
 
     /**
@@ -32,7 +39,7 @@ class EventDispatcher
      */
     public function dispatch($name, array $params)
     {
-        if (true == \Configuration::get(Config::PS_FACEBOOK_PIXEL_ENABLED)) {
+        if (true === (bool) $this->configurationAdapter->get(Config::PS_FACEBOOK_PIXEL_ENABLED)) {
             $this->conversionHandler->handleEvent($name, $params);
             $this->pixelHandler->handleEvent($name, $params);
         }

--- a/config/common/dispatcher.yml
+++ b/config/common/dispatcher.yml
@@ -4,3 +4,4 @@ services:
     arguments:
       - '@PrestaShop\Module\PrestashopFacebook\Handler\ApiConversionHandler'
       - '@PrestaShop\Module\PrestashopFacebook\Handler\PixelHandler'
+      - '@PrestaShop\Module\PrestashopFacebook\Adapter\ConfigurationAdapter'


### PR DESCRIPTION
Switch on the configuration page for Pixel was always displayed as "true", even if the feature was disabled in database