### PR TITLE
Check FBE features before displaying messenger

### DIFF
--- a/config/common/handler.yml
+++ b/config/common/handler.yml
@@ -18,6 +18,7 @@ services:
     class: PrestaShop\Module\PrestashopFacebook\Handler\MessengerHandler
     arguments:
       - '@ps_facebook.language'
+      - '@PrestaShop\Module\PrestashopFacebook\Provider\FbeFeatureDataProvider'
 
   PrestaShop\Module\PrestashopFacebook\Handler\PixelHandler:
     class: PrestaShop\Module\PrestashopFacebook\Handler\PixelHandler


### PR DESCRIPTION
Even if we disable messenger on the back office, it was still displayed on the front office. We have to call FBE API to check if we are allowed to display it.