### PR TITLE
Display loading spinner when unlinking account with facebook

### DIFF
--- a/_dev/src/views/configuration.vue
+++ b/_dev/src/views/configuration.vue
@@ -286,8 +286,10 @@ export default defineComponent({
       this.showGlass = true;
     },
     onUninstallClick() {
+      this.loading = true;
       fetch(this.fbeOnboardingUninstallRoute)
         .then((res) => {
+          this.loading = false;
           if (!res.ok) {
             throw new Error(res.statusText || res.status);
           }


### PR DESCRIPTION
Unlinking a facebook account from PrestaShop may take some time. To avoid the merchant to run other actions while this action is done, we now display the loading spinner.