### PR TITLE
Add notice with HTML content on catalog tab

### DIFF
--- a/_dev/src/components/catalog/summary/match-categories.vue
+++ b/_dev/src/components/catalog/summary/match-categories.vue
@@ -37,7 +37,16 @@
     >
       {{ $t('catalogSummary.matchCategoriesButton') }}
     </b-button>
-    <p>{{ $t('catalogSummary.categoryMatchingIntro') }}</p>
+    <p class="text">
+      {{ $t('catalogSummary.categoryMatchingIntro') }}
+      <b-alert
+        variant="info"
+        class="small-text"
+        show
+      >
+        <span v-html="textCategoryMatchingNotice"></span>
+      </b-alert>
+    </p>
   </div>
 </template>
 
@@ -57,11 +66,31 @@ export default defineComponent({
       illustration,
     };
   },
+  computed: {
+    textCategoryMatchingNotice() {
+      return this.$i18n.t('catalogSummary.categoryMatchingNotice')
+        .replace('[1]', '<u><b>')
+        .replace('[/1]', '</b></u>');
+    },
+  },
 });
 </script>
 
 <style lang="scss" scoped>
   .title {
     font-weight: 600;
+  }
+  .text {
+    display: flow-root;
+
+    & > div {
+      margin-top: 1em;
+      padding-left: 3.8rem !important;
+      padding-right: 0.5rem !important;
+
+      span {
+        padding: 0 !important;
+      }
+    }
   }
 </style>


### PR DESCRIPTION
After #105 that added some wording, this PR adds one of the new string on the catalog tab. 


![image](https://user-images.githubusercontent.com/6768917/99437131-f6faad00-2909-11eb-96a9-d123c7737359.png)

