### PR TITLE
Update externalBusinessId for other components

### DIFF
--- a/_dev/src/components/features/available-feature.vue
+++ b/_dev/src/components/features/available-feature.vue
@@ -64,7 +64,7 @@ export default defineComponent({
       required: false,
       default: () => ({
         // Duplicates ./enabled-feature.vue
-        default: global.facebookManageFeaturesRoute,
+        default: `https://www.facebook.com/facebook_business_extension?app_id=${global.psFacebookAppId}&external_business_id=${global.psFacebookExternalBusinessId}`,
         page_cta: `https://www.facebook.com/${global.contextPsFacebook.page.id}`,
       }),
     },

--- a/_dev/src/components/features/enabled-feature.vue
+++ b/_dev/src/components/features/enabled-feature.vue
@@ -149,7 +149,7 @@ export default defineComponent({
       required: false,
       default: () => ({
         // Duplicates ./available-feature.vue
-        default: global.facebookManageFeaturesRoute,
+        default: `https://www.facebook.com/facebook_business_extension?app_id=${global.psFacebookAppId}&external_business_id=${global.psFacebookExternalBusinessId}`,
         page_cta: `https://www.facebook.com/${global.contextPsFacebook.page.id}`,
       }),
     },

--- a/_dev/src/main.ts
+++ b/_dev/src/main.ts
@@ -29,6 +29,8 @@ new Vue({
     return {
       // @ts-ignore
       contextPsFacebook: global.contextPsFacebook,
+      // @ts-ignore
+      psFacebookExternalBusinessId: global.psFacebookExternalBusinessId,
     };
   },
   methods: {
@@ -36,6 +38,11 @@ new Vue({
       this.contextPsFacebook = context;
       // @ts-ignore
       global.contextPsFacebook = context;
+    },
+    refreshExternalBusinessId(externalBusinessId) {
+      this.psFacebookExternalBusinessId = externalBusinessId;
+      // @ts-ignore
+      global.psFacebookExternalBusinessId = externalBusinessId;
     },
   },
 }).$mount('#app');

--- a/_dev/src/views/configuration.vue
+++ b/_dev/src/views/configuration.vue
@@ -407,6 +407,7 @@ export default defineComponent({
           }
           this.dynamicExternalBusinessId = res.externalBusinessId;
           this.openPopup = generateOpenPopup(this, this.psFacebookUiUrl);
+          this.$root.refreshExternalBusinessId(res.externalBusinessId);
         });
       }
 

--- a/controllers/admin/AdminPsfacebookModuleController.php
+++ b/controllers/admin/AdminPsfacebookModuleController.php
@@ -32,6 +32,12 @@ class AdminPsfacebookModuleController extends ModuleAdminController
         $defaultCurrency = $this->context->currency;
         $defaultLanguage = $this->context->language;
 
+        if ($externalBusinessId) {
+            Media::addJsDef([
+                'psFacebookExternalBusinessId' => $externalBusinessId,
+            ]);
+        }
+
         Media::addJsDef([
             'contextPsAccounts' => $psAccountPresenter->present(),
             'psAccountsToken' => $psAccountsService->getOrRefreshToken(),
@@ -127,7 +133,6 @@ class AdminPsfacebookModuleController extends ModuleAdminController
                     'ajax' => 1,
                 ]
             ),
-            'facebookManageFeaturesRoute' => "https://www.facebook.com/facebook_business_extension?app_id=$appId&external_business_id=$externalBusinessId",
             'psFacebookStartProductSyncRoute' => $this->context->link->getAdminLink(
                 'AdminAjaxPsfacebook',
                 true,


### PR DESCRIPTION
When we make the full onboarding on the module (PS Account, Facebook), then try to add messenger **without** refreshing a single time, the external business ID is not set.
This make merchant opening a facebook page without parameter and leads him to a HTTP 404.

This PR allows the refreshing of the global variable for external business ID, as done for the FB context.