### PR TITLE
Force display of shop selector

### DIFF
--- a/_dev/src/views/configuration.vue
+++ b/_dev/src/views/configuration.vue
@@ -17,8 +17,14 @@
  * International Registered Trademark & Property of PrestaShop SA
  *-->
 <template>
+  <MultiStoreSelector
+    v-if="!contextPsAccounts.isShopContext"
+    :shops="contextPsAccounts.shops"
+    class="m-3"
+    @shop-selected="onShopSelected($event)"
+  />
   <div
-    v-if="loading"
+    v-else-if="loading"
     class="page-spinner"
   />
   <div
@@ -95,7 +101,7 @@
 
 <script>
 import {defineComponent} from '@vue/composition-api';
-import {PsAccounts} from 'prestashop_accounts_vue_components';
+import {MultiStoreSelector, PsAccounts} from 'prestashop_accounts_vue_components';
 import Introduction from '../components/configuration/introduction.vue';
 import Messages from '../components/configuration/messages.vue';
 import NoConfig from '../components/configuration/no-config.vue';
@@ -133,6 +139,7 @@ export default defineComponent({
   components: {
     Introduction,
     Messages,
+    MultiStoreSelector,
     PsAccounts,
     NoConfig,
     FacebookNotConnected,
@@ -400,6 +407,9 @@ export default defineComponent({
         this.popupReceptionDuplicate = false;
         this.$forceUpdate();
       });
+    },
+    onShopSelected(shopSelected) {
+      window.location.href = shopSelected.url;
     },
     createExternalBusinessId() {
       if (!this.psFacebookRetrieveExternalBusinessId) {

--- a/controllers/admin/AdminPsfacebookModuleController.php
+++ b/controllers/admin/AdminPsfacebookModuleController.php
@@ -29,7 +29,6 @@ class AdminPsfacebookModuleController extends ModuleAdminController
         //todo: add module version validation so merchant can see that he needs to upgrade module
         $psAccountPresenter = new PsAccountsPresenter($this->module->name);
         $psAccountsService = new PsAccountsService();
-        $appId = $_ENV['PSX_FACEBOOK_APP_ID'];
         $externalBusinessId = $this->configurationAdapter->get(Config::PS_FACEBOOK_EXTERNAL_BUSINESS_ID);
 
         $this->context->smarty->assign([
@@ -50,7 +49,7 @@ class AdminPsfacebookModuleController extends ModuleAdminController
         }
 
         Media::addJsDef([
-            'contextPsAccounts' => $psAccountPresenter->present(),
+            'contextPsAccounts' => $this->psAccountsHotFix($psAccountPresenter->present()),
             'psAccountsToken' => $psAccountsService->getOrRefreshToken(),
             'psFacebookAppId' => $_ENV['PSX_FACEBOOK_APP_ID'],
             'psFacebookFbeUiUrl' => $_ENV['PSX_FACEBOOK_UI_URL'],
@@ -213,5 +212,32 @@ class AdminPsfacebookModuleController extends ModuleAdminController
         if (!empty($access_token)) {
             $this->configurationAdapter->updateValue(Config::PS_FACEBOOK_USER_ACCESS_TOKEN, $access_token);
         }
+    }
+
+    /**
+     * Quickfix for multishop with PS Accounts.
+     * The shop in the Context class is always defined, even if multistore. This means the multistore selector
+     * is never displayed at the moment.
+
+     * TODO : Move in https://github.com/PrestaShopCorp/prestashop_accounts_vue_components
+     */
+    private function psAccountsHotFix($presentedData)
+    {
+        $presentedData['isShopContext'] = Shop::getContext() === Shop::CONTEXT_SHOP;
+        foreach ($presentedData['shops'] as $groupKey => &$shopGroup) {
+            foreach ($shopGroup['shops'] as &$shop) {
+                $shop['url'] = $this->context->link->getAdminLink(
+                    'AdminModules',
+                    true,
+                    [],
+                    [
+                        'configure' => $this->module->name,
+                        'setShopContext' => 's-' . $shop['id'],
+                    ]
+                );
+            }
+        }
+
+        return $presentedData;
     }
 }


### PR DESCRIPTION
This PR force the display of multishop selector on the configuration page.

These improvement must be added on the different accounts libraries. However, having them in the Facebook module as well will allow the feature to work even if an old version of the lib is loaded in memory from another module.