### PR TITLE
Fix error on product page caused by empty value

### DIFF
--- a/classes/Provider/EventDataProvider.php
+++ b/classes/Provider/EventDataProvider.php
@@ -127,7 +127,7 @@ class EventDataProvider
             $product['id_product_attribute']
         );
 
-        $productUrl = $this->context->link->getProductLink($product->id);
+        $productUrl = $this->context->link->getProductLink($product['id']);
         $content = [
             'id' => $fbProductId,
             'title' => \Tools::replaceAccentedChars($product['name']),


### PR DESCRIPTION
Data returned by `ProductController::getTemplateVarProduct();` should be used as an array, not an object. This fixes a fatal error on the product page