### PR TITLE
Display an alert when PS Accounts needs to be upgraded

### DIFF
--- a/_dev/.storybook/translations.json
+++ b/_dev/.storybook/translations.json
@@ -29,7 +29,11 @@
         "shopInConflictError": "This domain has already been linked with PS Accounts and Facebook by another shop of this PrestaShop instance. \nAt the moment PrestaShop Account is unable to work when two shops share the same domain. \n\n\n\nTo register this shop, you must first: \n- unregister your Facebook account from the other one using the same domain, \n- or change the domain name of this shop.",
 
         "unknownOnboardingError": "An unknown error occurred during onboarding process. Please reload and try again.",
-        "reloadButton": "Reload"
+        "reloadButton": "Reload",
+
+        "psAccountUpgradeNeededWarning": "The version of the module PrestaShop Account running on this shop (v{psAccountsVersion}) is older than the minimum required v{requiredPsAccountsVersion}.\n\nYou may use PrestaShop Facebook but some features (i.e product synchronization) won't be available until you upgrade PrestaShop Account.",
+        "psAccountUpgradeButton": "Upgrade PrestaShop Accounts",
+        "psAccountUpgradeDone": "PrestaShop Account has been successfully upgraded."
       },
       "facebook": {
         "title": "Your Facebook settings",

--- a/_dev/src/components/warning/ps-accounts-update-needed.vue
+++ b/_dev/src/components/warning/ps-accounts-update-needed.vue
@@ -1,0 +1,126 @@
+<!--**
+ * 2007-2020 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *-->
+<template>
+  <b-alert
+    variant="warning"
+    class="m-3"
+    show
+    v-if="!upgradeDone"
+  >
+    <div>
+      <p
+        v-html="md2html($t('configuration.messages.psAccountUpgradeNeededWarning', this))"
+      />
+      <div
+        v-if="loading"
+        class="spinner mt-2"
+      />
+      <b-button
+        v-else
+        variant="primary"
+        class="mt-2"
+        @click="onUpgradeClick"
+      >
+        {{ $t('configuration.messages.psAccountUpgradeButton') }}
+      </b-button>
+    </div>
+  </b-alert>
+  <b-alert
+    v-else
+    variant="success"
+    class="m-3"
+    show
+    dismissible
+  >
+    {{ $t('configuration.messages.psAccountUpgradeDone') }}
+  </b-alert>
+</template>
+
+<script>
+import {defineComponent} from '@vue/composition-api';
+import Showdown from 'showdown';
+import {
+  BAlert,
+} from 'bootstrap-vue';
+
+export default defineComponent({
+  name: 'Configuration',
+  components: {
+    BAlert,
+  },
+  mixins: [],
+  data() {
+    return {
+      upgradeDone: false,
+      loading: false,
+    };
+  },
+  props: {
+    psAccountsVersion: {
+      type: String,
+      required: false,
+      default: () => global.psAccountVersionCheck.psAccountsVersion || null,
+    },
+    requiredPsAccountsVersion: {
+      type: String,
+      required: false,
+      default: () => global.psAccountVersionCheck.requiredPsAccountsVersion || null,
+    },
+    psFacebookUpgradePsAccounts: {
+      type: String,
+      required: false,
+      default: () => global.psAccountVersionCheck.psFacebookUpgradePsAccounts || null,
+    },
+  },
+  methods: {
+    md2html: (md) => (new Showdown.Converter()).makeHtml(md),
+    onUpgradeClick() {
+      this.loading = true;
+
+      fetch(this.psFacebookUpgradePsAccounts, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json', Accept: 'application/json'},
+      }).then((res) => {
+        if (!res.ok) {
+          throw new Error(res.statusText || res.status);
+        }
+        return res.json();
+      }).then((res) => {
+        if (!res.success) {
+          throw new Error('Error!');
+        }
+        this.loading = false;
+        this.upgradeDone = true;
+        this.$segment.track('PS Account upgraded from alert', {
+          module: 'ps_facebook',
+        });
+      }).catch((error) => {
+        console.error(error);
+        this.loading = false;
+        this.$segment.track('Upgrade of PS Accounts failed', {
+          module: 'ps_facebook',
+        });
+      });
+    },
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+</style>

--- a/_dev/src/views/configuration.vue
+++ b/_dev/src/views/configuration.vue
@@ -47,6 +47,9 @@
         @onAdCampaignClick="onAdCampaignClick"
         class="m-3"
       />
+      <PsAccountsUpdateNeeded
+        v-if="needsPsAccountsUpgrade"
+      />
       <b-alert
         v-if="psAccountShopInConflict"
         variant="danger"
@@ -117,6 +120,7 @@ import FacebookConnected from '../components/configuration/facebook-connected.vu
 import FacebookNotConnected from '../components/configuration/facebook-not-connected.vue';
 import Survey from '../components/survey/survey.vue';
 import openPopupGenerator from '../lib/fb-login';
+import PsAccountsUpdateNeeded from '../components/warning/ps-accounts-update-needed.vue';
 
 const generateOpenPopup = (component, popupUrl) => {
   const canGeneratePopup = (
@@ -151,6 +155,7 @@ export default defineComponent({
     Messages,
     MultiStoreSelector,
     PsAccounts,
+    PsAccountsUpdateNeeded,
     NoConfig,
     FacebookNotConnected,
     FacebookConnected,
@@ -228,6 +233,11 @@ export default defineComponent({
       required: false,
       default: () => global.psFacebookRetrieveExternalBusinessId || null,
     },
+    psAccountVersionCheck: {
+      type: Boolean,
+      required: false,
+      default: () => global.psAccountVersionCheck,
+    },
   },
   computed: {
     psAccountsOnboarded() {
@@ -259,6 +269,9 @@ export default defineComponent({
         !c.catalog
         || (c.catalog.categoryMatchingStarted !== true || c.catalog.productSyncStarted !== true)
       );
+    },
+    needsPsAccountsUpgrade() {
+      return this.psAccountVersionCheck && this.psAccountVersionCheck.needsPsAccountsUpgrade;
     },
   },
   data() {

--- a/classes/Translations/PsFacebookTranslations.php
+++ b/classes/Translations/PsFacebookTranslations.php
@@ -86,6 +86,9 @@ class PsFacebookTranslations
                     'reloadButton' => $this->module->l('Reload', 'PsFacebookTranslations'),
                     'shopInConflictError' => $this->module->l("This domain has already been linked with PS Accounts and Facebook by another shop of this PrestaShop instance. \nAt the moment PrestaShop Account is unable to work when two shops share the same domain. \n\nTo register this shop, you must first: \n- unregister your Facebook account from the other one using the same domain, \n- or change the domain name of this shop.", 'PsFacebookTranslations'),
                     'unknownOnboardingError' => $this->module->l('An unknown error occurred during onboarding process. Please reload and try again.', 'PsFacebookTranslations'),
+                    'psAccountUpgradeNeededWarning' => $this->module->l("The version of the module PrestaShop Account running on this shop (v{psAccountsVersion}) is older than the minimum required v{requiredPsAccountsVersion}.\n\nYou may use PrestaShop Facebook but some features (i.e product synchronization) won't be available until you upgrade PrestaShop Account.", 'PsFacebookTranslations'),
+                    'psAccountUpgradeButton' => $this->module->l('Upgrade PrestaShop Accounts', 'PsFacebookTranslations'),
+                    'psAccountUpgradeDone' => $this->module->l('PrestaShop Account has been successfully upgraded.', 'PsFacebookTranslations'),
                 ],
                 'facebook' => [
                     'title' => $this->module->l('Your Facebook settings', 'PsFacebookTranslations'),


### PR DESCRIPTION
## Initial display

![Capture d’écran du 2020-12-23 16-29-03](https://user-images.githubusercontent.com/6768917/103013804-08089080-453e-11eb-91f0-e20119392735.png)

## Upgrade in progress

![Capture d’écran du 2020-12-23 16-29-17](https://user-images.githubusercontent.com/6768917/103013827-15257f80-453e-11eb-8cf2-f3cb67767b36.png)

## Upgrade done

![Capture d’écran du 2020-12-23 16-29-32](https://user-images.githubusercontent.com/6768917/103013849-1b1b6080-453e-11eb-9e75-687806d5bb77.png)
Note this screenshot is an old version, and the alert can be dismissed