### PR TITLE
Disable error handler of facebook php lib

### DIFF
--- a/classes/Handler/ApiConversionHandler.php
+++ b/classes/Handler/ApiConversionHandler.php
@@ -60,7 +60,8 @@ class ApiConversionHandler
         Api::init(
             null, // app_id
             null, // app_secret
-            $this->configurationAdapter->get(Config::PS_FACEBOOK_SYSTEM_ACCESS_TOKEN)
+            $this->configurationAdapter->get(Config::PS_FACEBOOK_SYSTEM_ACCESS_TOKEN),
+            false
         );
     }
 


### PR DESCRIPTION
The FB library we include in the project has its own Error Handler. Any error thrown on the shop will be caught by this handler, then sent to us.

We receive some noise because of a lack of filtering, and it would be better to disable it for the moment.