### PR TITLE
Fix - Fixed ci/cd docker ancestor

### DIFF
--- a/.github/workflows/ci-cd-alpha.yml
+++ b/.github/workflows/ci-cd-alpha.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - fix/ci-cd-ancestor
   pull_request:
     types: [opened,edited,reopened,synchronize,labeled]
 
@@ -19,7 +18,7 @@ jobs:
     name: CI/CD integration ps_facebook
     runs-on: ubuntu-latest
     timeout-minutes: 10
-#    if: contains(github.event.pull_request.labels.*.name, 'quality assurance needed') || github.ref == 'refs/heads/dev'
+    if: contains(github.event.pull_request.labels.*.name, 'quality assurance needed') || github.ref == 'refs/heads/dev'
 
     steps:
       # Fixed babel build : https://github.com/ember-cli/ember-cli/issues/9235#issuecomment-635254959


### PR DESCRIPTION
Backporting fix on branch 1.4.x https://github.com/PrestaShopCorp/ps_facebook/pull/211

- Select correct prestashop version on docker filter