### PR TITLE
Empty page to be totally empty by matching condition of Multistore component

### DIFF
--- a/_dev/src/views/configuration.vue
+++ b/_dev/src/views/configuration.vue
@@ -29,8 +29,8 @@
       class="m-3"
     />
     <MultiStoreSelector
-      v-else-if="!contextPsAccounts.isShopContext"
-      :shops="contextPsAccounts.shops || []"
+      v-else-if="!contextPsAccounts.isShopContext && shops.length"
+      :shops="shops"
       class="m-3"
       @shop-selected="onShopSelected($event)"
     />
@@ -286,6 +286,7 @@ export default defineComponent({
       loading: true,
       popupReceptionDuplicate: false,
       openedPopup: null,
+      shops: this.contextPsAccounts.shops || [],
     };
   },
   created() {


### PR DESCRIPTION
@margud found out that removing the ps_account module made our module behaving badly.

There is a second if the multistore alert that made the page empty. To avoid this case, we had a condition to our `v-if` that matches the component one.