### PR TITLE
Bring back PS Account component with install button

### DIFF
--- a/controllers/admin/AdminPsfacebookModuleController.php
+++ b/controllers/admin/AdminPsfacebookModuleController.php
@@ -319,10 +319,6 @@ class AdminPsfacebookModuleController extends ModuleAdminController
 
     private function presentPsAccounts()
     {
-        if (!Module::isInstalled('ps_accounts') || false === Module::getInstanceByName('ps_accounts')) {
-            return [];
-        }
-
         $this->psAccountsEnvVarHotFix();
 
         $psAccountPresenter = new PsAccountsPresenter($this->module->name);


### PR DESCRIPTION
As https://github.com/PrestaShopCorp/prestashop_accounts_auth/pull/55 has been merged, we can now remove a condition that prevent the "install button" of PS Account to be displayed