### PR TITLE
Use github.ref in sentry publish github action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,3 +40,4 @@ jobs:
         SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
       with:
         environment: production
+        version: ${{ github.ref }}


### PR DESCRIPTION
On sentry, releases are named with the commit sha1. It would be better to have the version name, such as `v1.5.0`

![image](https://user-images.githubusercontent.com/6768917/107979521-f92edf00-6fbe-11eb-868e-7f176a2c47cb.png)
