### PR TITLE
Delay the call to parent::install() to avoid partially installed module (Avoid missing controllers)

### DIFF
--- a/classes/Database/Installer.php
+++ b/classes/Database/Installer.php
@@ -64,7 +64,6 @@ class Installer
         $this->segment->track();
 
         return $this->installConfiguration() &&
-            $this->module->registerHook(\Ps_facebook::HOOK_LIST) &&
             $this->installTabs() &&
             $this->installTables();
     }

--- a/ps_facebook.php
+++ b/ps_facebook.php
@@ -211,22 +211,16 @@ class Ps_facebook extends Module
      */
     public function install()
     {
-        // We can't init the Uninstaller in CLI, as it has been declared in the admin container and PrestaShop
-        // does not have the _PS_ADMIN_DIR_ in this environment.
-        // prestashop/module-lib-service-container:1.3.1 is known as incompatible
-        // $installer = $this->getService(Installer::class);
-        if (!parent::install()) {
-            $this->_errors[] = $this->l('Unable to install module');
-
-            return false;
-        }
-
         if (!(new PrestaShop\AccountsAuth\Installer\Install())->installPsAccounts()) {
             $this->_errors[] = $this->l('Unable to install ps accounts');
 
             return false;
         }
 
+        // We can't init the Uninstaller in CLI, as it has been declared in the admin container and PrestaShop
+        // does not have the _PS_ADMIN_DIR_ in this environment.
+        // prestashop/module-lib-service-container:1.3.1 is known as incompatible
+        // $installer = $this->getService(Installer::class);
         $installer = new Installer(
             $this,
             $this->getService(Segment::class),
@@ -238,6 +232,14 @@ class Ps_facebook extends Module
 
             return false;
         }
+
+        if (!parent::install()) {
+            $this->_errors[] = $this->l('Unable to install module');
+
+            return false;
+        }
+
+        $this->registerHook(static::HOOK_LIST);
 
         return true;
     }


### PR DESCRIPTION
During installation, delay the call to `parent::install()`.

Until we call this method, this module will remain non-installed if one of the previous steps fails, allowing the merchant to replay the installation. 