### PR TITLE
Restrict Pixel events to front office (Fix an error while sending messages on BO)

### DIFF
--- a/classes/Dispatcher/EventDispatcher.php
+++ b/classes/Dispatcher/EventDispatcher.php
@@ -20,6 +20,7 @@
 
 namespace PrestaShop\Module\PrestashopFacebook\Dispatcher;
 
+use Context;
 use PrestaShop\Module\PrestashopFacebook\Adapter\ConfigurationAdapter;
 use PrestaShop\Module\PrestashopFacebook\Config\Config;
 use PrestaShop\Module\PrestashopFacebook\Handler\ApiConversionHandler;
@@ -48,16 +49,23 @@ class EventDispatcher
      */
     private $eventDataProvider;
 
+    /**
+     * @var Context
+     */
+    private $context;
+
     public function __construct(
         ApiConversionHandler $apiConversionHandler,
         PixelHandler $pixelHandler,
         ConfigurationAdapter $configurationAdapter,
-        EventDataProvider $eventDataProvider
+        EventDataProvider $eventDataProvider,
+        Context $context
     ) {
         $this->conversionHandler = $apiConversionHandler;
         $this->pixelHandler = $pixelHandler;
         $this->configurationAdapter = $configurationAdapter;
         $this->eventDataProvider = $eventDataProvider;
+        $this->context = $context;
     }
 
     /**
@@ -68,6 +76,11 @@ class EventDispatcher
      */
     public function dispatch($name, array $params)
     {
+        // Events are related to actions on the shop, not the back office
+        if (!in_array($this->context->controller->controller_type, ['front', 'modulefront'])) {
+            return;
+        }
+
         if (true === (bool) $this->configurationAdapter->get(Config::PS_FACEBOOK_PIXEL_ENABLED)) {
             $eventData = $this->eventDataProvider->generateEventData($name, $params);
 

--- a/classes/Provider/EventDataProvider.php
+++ b/classes/Provider/EventDataProvider.php
@@ -112,7 +112,7 @@ class EventDataProvider
                 if ($controllerPage === 'product') {
                     return $this->getProductPageData();
                 }
-                if ($controllerPage === 'category' && $this->context->controller->controller_type === 'front') {
+                if ($controllerPage === 'category') {
                     return $this->getCategoryPageData();
                 }
                 if ($controllerPage === 'cms') {

--- a/config/common/dispatcher.yml
+++ b/config/common/dispatcher.yml
@@ -6,3 +6,4 @@ services:
       - '@PrestaShop\Module\PrestashopFacebook\Handler\PixelHandler'
       - '@PrestaShop\Module\PrestashopFacebook\Adapter\ConfigurationAdapter'
       - '@PrestaShop\Module\PrestashopFacebook\Provider\EventDataProvider'
+      - '@ps_facebook.context'


### PR DESCRIPTION
We don't need to sent to Facebook Pixel events that are occuring from the Back office, as only the browsing on the shop is interesting for the merchant.

Also fixes the error found on Back office on PS 1.7.7+ when a message is sent to a customer:

```
Type error: Argument 1 passed to PrestaShop\Module\Ps_facebook\Utility\CustomerInformationUtility::getCustomerInformationForPixel() must be an instance of Customer, null given, called in modules/ps_facebook/classes/Provider/EventDataProvider.php on line 329
```