### PR TITLE
Do not call FB API when no Ads Account ID has been received

### DIFF
--- a/classes/API/FacebookClient.php
+++ b/classes/API/FacebookClient.php
@@ -129,19 +129,21 @@ class FacebookClient
      */
     public function getPixel($adId, $pixelId)
     {
-        $responseContent = $this->get('act_' . $adId . '/adspixels', __FUNCTION__, ['name', 'last_fired_time', 'is_unavailable']);
-
         $name = $lastFiredTime = null;
         $isUnavailable = false;
 
-        if (isset($responseContent['data'])) {
-            foreach ($responseContent['data'] as $adPixel) {
-                if ($adPixel['id'] !== $pixelId) {
-                    continue;
+        if (!empty($adId)) {
+            $responseContent = $this->get('act_' . $adId . '/adspixels', __FUNCTION__, ['name', 'last_fired_time', 'is_unavailable']);
+
+            if (isset($responseContent['data'])) {
+                foreach ($responseContent['data'] as $adPixel) {
+                    if ($adPixel['id'] !== $pixelId) {
+                        continue;
+                    }
+                    $name = isset($adPixel['name']) ? $adPixel['name'] : null;
+                    $lastFiredTime = isset($adPixel['last_fired_time']) ? $adPixel['last_fired_time'] : null;
+                    $isUnavailable = isset($adPixel['is_unavailable']) ? $adPixel['is_unavailable'] : null;
                 }
-                $name = isset($adPixel['name']) ? $adPixel['name'] : null;
-                $lastFiredTime = isset($adPixel['last_fired_time']) ? $adPixel['last_fired_time'] : null;
-                $isUnavailable = isset($adPixel['is_unavailable']) ? $adPixel['is_unavailable'] : null;
             }
         }
 


### PR DESCRIPTION
It seems that sometimes the API return an empty Ads ID. When this happens, there's no point in calling the API as it will always fail. I however don't return early as I still have to send an instance of the Pixel class.

Error returned by Facebook:
![image](https://user-images.githubusercontent.com/6768917/108736164-a494e200-7531-11eb-9203-57e3ba241ed5.png)

Related error en Sentry:
https://sentry.io/organizations/prestashop/issues/2220563275/?project=5531852&query=is%3Aunresolved+ps_facebook_version%3A1.5.1&statsPeriod=14d