### PR TITLE
Sales channels: Display FB features without switch as always enabled

### DIFF
--- a/_dev/src/components/features/enabled-feature.vue
+++ b/_dev/src/components/features/enabled-feature.vue
@@ -171,7 +171,7 @@ export default defineComponent({
   },
   data() {
     return {
-      switchActivated: this.active,
+      switchActivated: this.active || !this.allowDisplayOfSwitch,
       isLoading: this.loading,
     };
   },


### PR DESCRIPTION
Shop Page is a feature that is returned as disabled by facebook, while the FBE page says it is enabled.

This PR forces the display as enabled, so we at least get acess to the bouton "Manage".