### PR TITLE
Update Uninstall parameters

### DIFF
--- a/ps_facebook.php
+++ b/ps_facebook.php
@@ -19,12 +19,12 @@
  */
 
 use Dotenv\Dotenv;
+use PrestaShop\Module\PrestashopFacebook\API\FacebookClient;
 use PrestaShop\Module\PrestashopFacebook\Buffer\TemplateBuffer;
 use PrestaShop\Module\PrestashopFacebook\Config\Config;
 use PrestaShop\Module\PrestashopFacebook\Database\Installer;
 use PrestaShop\Module\PrestashopFacebook\Database\Uninstaller;
 use PrestaShop\Module\PrestashopFacebook\Dispatcher\EventDispatcher;
-use PrestaShop\Module\PrestashopFacebook\Handler\ConfigurationHandler;
 use PrestaShop\Module\PrestashopFacebook\Handler\ErrorHandler\ErrorHandler;
 use PrestaShop\Module\PrestashopFacebook\Handler\MessengerHandler;
 use PrestaShop\Module\PrestashopFacebook\Repository\TabRepository;
@@ -264,7 +264,7 @@ class Ps_facebook extends Module
             $this->getService(TabRepository::class),
             $this->getService(Segment::class),
             $this->getService(ErrorHandler::class),
-            $this->getService(ConfigurationHandler::class)
+            $this->getService(FacebookClient::class)
         );
 
         return $uninstaller->uninstall() &&


### PR DESCRIPTION
On https://github.com/PrestaShopCorp/ps_facebook/pull/254 the parameters of the Uninstall constructor have been updated.

We forgot the instanciation in the `ps_facebook.php` class, throwing exceptions when we uninstall the module.