### PR TITLE
Do no call anymore FB API in front office to check messenger feature

### DIFF
--- a/classes/Handler/MessengerHandler.php
+++ b/classes/Handler/MessengerHandler.php
@@ -24,7 +24,6 @@ use Language;
 use PrestaShop\Module\PrestashopFacebook\Adapter\ConfigurationAdapter;
 use PrestaShop\Module\PrestashopFacebook\Config\Config;
 use PrestaShop\Module\PrestashopFacebook\Config\Env;
-use PrestaShop\Module\PrestashopFacebook\Provider\FbeFeatureDataProvider;
 
 class MessengerHandler
 {
@@ -39,9 +38,9 @@ class MessengerHandler
     private $lang;
 
     /**
-     * @var FbeFeatureDataProvider
+     * @var ConfigurationAdapter
      */
-    private $fbeFeatureDataProvider;
+    private $configurationAdapter;
 
     /**
      * @var Env
@@ -50,14 +49,13 @@ class MessengerHandler
 
     public function __construct(
         Language $lang,
-        FbeFeatureDataProvider $fbeFeatureDataProvider,
         ConfigurationAdapter $configurationAdapter,
         Env $env
     ) {
         $pageList = explode(',', $configurationAdapter->get('PS_FACEBOOK_PAGES'));
         $this->pageId = (int) reset($pageList);
         $this->lang = $lang;
-        $this->fbeFeatureDataProvider = $fbeFeatureDataProvider;
+        $this->configurationAdapter = $configurationAdapter;
         $this->env = $env;
     }
 
@@ -70,13 +68,9 @@ class MessengerHandler
             return false;
         }
 
-        // This makes a API call to FB, it may need to be cached
-        $fbeFeatures = $this->fbeFeatureDataProvider->getFbeFeatures();
-        if (!isset($fbeFeatures['enabledFeatures']['messenger_chat']['enabled'])) {
-            return false;
-        }
+        $messengerChatFeature = json_decode($this->configurationAdapter->get(Config::FBE_FEATURE_CONFIGURATION . 'messenger_chat'));
 
-        return (bool) $fbeFeatures['enabledFeatures']['messenger_chat']['enabled'];
+        return $messengerChatFeature && $messengerChatFeature->enabled;
     }
 
     public function handle()

--- a/classes/Manager/FbeFeatureManager.php
+++ b/classes/Manager/FbeFeatureManager.php
@@ -63,6 +63,8 @@ class FbeFeatureManager
         }
 
         $featureConfiguration->enabled = (bool) $state;
+        $this->configurationAdapter->updateValue(Config::FBE_FEATURE_CONFIGURATION . $featureName, json_encode($featureConfiguration));
+
         $configuration = [
             $featureName => $featureConfiguration,
         ];

--- a/classes/Provider/FbeFeatureDataProvider.php
+++ b/classes/Provider/FbeFeatureDataProvider.php
@@ -57,7 +57,7 @@ class FbeFeatureDataProvider
         }, ARRAY_FILTER_USE_KEY);
 
         foreach ($features as $featureName => $feature) {
-            if ($feature['enabled']) {
+            if ($this->configurationAdapter->get(Config::FBE_FEATURE_CONFIGURATION . $featureName) !== false) {
                 $this->configurationAdapter->updateValue(Config::FBE_FEATURE_CONFIGURATION . $featureName, json_encode($feature));
             }
         }

--- a/config/common/handler.yml
+++ b/config/common/handler.yml
@@ -20,7 +20,6 @@ services:
     class: PrestaShop\Module\PrestashopFacebook\Handler\MessengerHandler
     arguments:
       - '@ps_facebook.language'
-      - '@PrestaShop\Module\PrestashopFacebook\Provider\FbeFeatureDataProvider'
       - '@PrestaShop\Module\PrestashopFacebook\Adapter\ConfigurationAdapter'
       - '@PrestaShop\Module\PrestashopFacebook\Config\Env'
 


### PR DESCRIPTION
We make too many call to the facebook API, and this is caused by the check of the messenger feature on front office.

With small changes, we can rely on the local data.