### PR TITLE
Restrict refreshing of token on AdminModule controllers only, so we avoid refreshing them in front office or on core controllers

### DIFF
--- a/classes/Provider/AccessTokenProvider.php
+++ b/classes/Provider/AccessTokenProvider.php
@@ -20,6 +20,7 @@
 
 namespace PrestaShop\Module\PrestashopFacebook\Provider;
 
+use Controller;
 use Exception;
 use GuzzleHttp\Exception\ClientException;
 use PrestaShop\Module\PrestashopFacebook\Adapter\ConfigurationAdapter;
@@ -47,6 +48,11 @@ class AccessTokenProvider
     private $errorHandler;
 
     /**
+     * @var Controller
+     */
+    private $controller;
+
+    /**
      * @var string
      */
     private $userAccessToken;
@@ -56,11 +62,16 @@ class AccessTokenProvider
      */
     private $systemAccessToken;
 
-    public function __construct(ConfigurationAdapter $configurationAdapter, Env $env, ErrorHandler $errorHandler)
-    {
+    public function __construct(
+        ConfigurationAdapter $configurationAdapter,
+        Env $env,
+        ErrorHandler $errorHandler,
+        Controller $controller
+    ) {
         $this->configurationAdapter = $configurationAdapter;
         $this->env = $env;
         $this->errorHandler = $errorHandler;
+        $this->controller = $controller;
     }
 
     /**
@@ -100,7 +111,7 @@ class AccessTokenProvider
         if ((!$this->systemAccessToken
                 || !$tokenExpirationDate
                 || ($tokenExpirationDate - $currentTimestamp <= 86400))
-            && \Context::getContext()->controller->controller_type !== 'front'
+            && $this->controller->controller_type === 'moduleadmin'
             && $this->userAccessToken
         ) {
             $this->refreshTokens();

--- a/config/common/provider.yml
+++ b/config/common/provider.yml
@@ -5,6 +5,7 @@ services:
       - '@PrestaShop\Module\PrestashopFacebook\Adapter\ConfigurationAdapter'
       - '@PrestaShop\Module\PrestashopFacebook\Config\Env'
       - '@PrestaShop\Module\PrestashopFacebook\Handler\ErrorHandler\ErrorHandler'
+      - '@ps_facebook.controller'
 
   PrestaShop\Module\PrestashopFacebook\Provider\GoogleCategoryProviderInterface: '@PrestaShop\Module\PrestashopFacebook\Provider\GoogleCategoryProvider'
 


### PR DESCRIPTION
This PR also adds the Controller as a class parameter with the service container

This fixes http://forge.prestashop.com/browse/EMKTG-617