### PR TITLE
Match display of pre-validation summary with reporting one

### DIFF
--- a/_dev/.storybook/translations.json
+++ b/_dev/.storybook/translations.json
@@ -92,6 +92,7 @@
       "preApprovalScanRefreshDate": "Last scan today at {0}",
       "preApprovalScanReadyToSync": "Ready to sync",
       "preApprovalScanNonSyncable": "Non-syncable",
+      "preApprovalScanRescan": "Rescan",
       "catalogExportWarning": "Products will be exported then updated every 24h.",
       "catalogExportDisclaimer": "By sharing your catalog, you agree PrestaShop may send all information related to the catalog products to Facebook.",
       "catalogExportPaused": "Paused",

--- a/_dev/src/components/catalog/summary/export-catalog.vue
+++ b/_dev/src/components/catalog/summary/export-catalog.vue
@@ -149,12 +149,6 @@
     </div>
 
     <template>
-      <div class="float-right">
-        <i
-          class="material-icons refresh-icon"
-          @click="rescan"
-        >loop</i>
-      </div>
       <h3>
         {{ $t('catalogSummary.preApprovalScanTitle') }}
       </h3>
@@ -165,6 +159,14 @@
           <b-col class="counter m-1 p-3">
             <i class="material-icons">sync</i>
             {{ $t('catalogSummary.preApprovalScanRefreshDate', ['']) }}
+            <br>
+            <button
+              class="btn btn-outline-secondary btn-sm float-right mt-3"
+              title="Rescan"
+              @click="rescan"
+            >
+              {{ $t('catalogSummary.preApprovalScanRescan') }}
+            </button>
             <span
               class="big mt-2"
             >

--- a/classes/Translations/PsFacebookTranslations.php
+++ b/classes/Translations/PsFacebookTranslations.php
@@ -150,6 +150,7 @@ class PsFacebookTranslations
                 'preApprovalScanRefreshDate' => $this->module->l('Last scan today at {0}', 'PsFacebookTranslations'),
                 'preApprovalScanReadyToSync' => $this->module->l('Ready to sync', 'PsFacebookTranslations'),
                 'preApprovalScanNonSyncable' => $this->module->l('Non-syncable', 'PsFacebookTranslations'),
+                'preApprovalScanRescan' => $this->module->l('Rescan', 'PsFacebookTranslations'),
                 'catalogExportWarning' => $this->module->l('Products will be exported then updated every 24h.', 'PsFacebookTranslations'),
                 'catalogExportDisclaimer' => $this->module->l('By sharing your catalog, you agree PrestaShop may send all information related to the catalog products to Facebook.', 'PsFacebookTranslations'),
                 'catalogExportPaused' => $this->module->l('Paused', 'PsFacebookTranslations'),


### PR DESCRIPTION
This pull-request suggests the update of the display for pre-validation results with the newer one for the reporting.

## Before

![Screenshot_2021-03-18 Facebook • L'équipe Planète Soif](https://user-images.githubusercontent.com/6768917/111670027-ae9bbf00-8817-11eb-9a7e-beae38ceb79c.png)

## After

![Screenshot_2021-03-18 Facebook • L'équipe Planète Soif(1)](https://user-images.githubusercontent.com/6768917/111670051-b5c2cd00-8817-11eb-8e22-aafebd5a4441.png)

