### PR TITLE
Display actions on reporting only when we have product ID

### DIFF
--- a/_dev/src/components/catalog/report-details/reporting-table.vue
+++ b/_dev/src/components/catalog/report-details/reporting-table.vue
@@ -65,6 +65,7 @@
         <b-link
           :href="url.replace('/1?', `/${id_product}?`)"
           target="_blank"
+          v-if="id_product"
         >
           <i class="material-icons">edit</i>
         </b-link>


### PR DESCRIPTION
Fixes

![image](https://user-images.githubusercontent.com/6768917/111801666-6fc84080-88cd-11eb-97fd-c05d28ca005b.png)

where the actions in the last line should not be displayed as we don't have the product ID