### PR TITLE
Do not send Pixel Contact event when customer message is private

### DIFF
--- a/ps_facebook.php
+++ b/ps_facebook.php
@@ -393,6 +393,12 @@ class Ps_facebook extends Module
 
     public function hookActionObjectCustomerMessageAddAfter(array $params)
     {
+        if (isset($params['object'])
+            && $params['object'] instanceof CustomerMessage
+            && $params['object']->private) {
+            return;
+        }
+
         /** @var EventDispatcher $eventDispatcher */
         $eventDispatcher = $this->getService(EventDispatcher::class);
         $eventDispatcher->dispatch(__FUNCTION__, $params);


### PR DESCRIPTION
While making orders on a shop, I saw that a `contact` event was sent to Facebook.

This a message generated by the shop that is internal and private (= not visible for the customer). No need to notify Pixel about it.