### PR TITLE
Fix type of data returned while checking token are exchanged

### DIFF
--- a/controllers/admin/AdminAjaxPsfacebookController.php
+++ b/controllers/admin/AdminAjaxPsfacebookController.php
@@ -89,7 +89,7 @@ class AdminAjaxPsfacebookController extends ModuleAdminController
         $this->ajaxDie(
             json_encode(
                 [
-                    'success' => $accessTokenProvider->getSystemAccessToken(),
+                    'success' => (bool) $accessTokenProvider->getSystemAccessToken(),
                 ]
             )
         );


### PR DESCRIPTION
The Vue.js application waits for a boolean to confirm the token has been exchanged properly.

Because we return a string, an error was always displayed in the browser console.