### PR TITLE
Pixel - Make content IDs matching products IDs synchronized with Facebook Catalog

### DIFF
--- a/classes/Provider/EventDataProvider.php
+++ b/classes/Provider/EventDataProvider.php
@@ -214,11 +214,21 @@ class EventDataProvider
         $breadcrumbs = $controller->getBreadcrumbLinks();
         $breadcrumb = implode(' > ', array_column($breadcrumbs['links'], 'title'));
 
+        $contentIds = [];
+        if ($prods) {
+            foreach ($prods as $product) {
+                $contentIds[] = ProductCatalogUtility::makeProductId(
+                    $product['id_product'],
+                    $product['id_product_attribute']
+                );
+            }
+        }
+
         $customData = [
             'content_name' => \Tools::replaceAccentedChars($category->name) . ' ' . $this->locale,
             'content_category' => \Tools::replaceAccentedChars($breadcrumb),
             'content_type' => self::CATEGORY_TYPE,
-            'content_ids' => $prods ? array_column($prods, 'id_product') : null,
+            'content_ids' => $contentIds ?: null,
         ];
 
         return [
@@ -287,7 +297,12 @@ class EventDataProvider
         $customData = [
             'content_name' => pSQL($productName),
             'content_type' => self::PRODUCT_TYPE,
-            'content_ids' => [$idProduct],
+            'content_ids' => [
+                ProductCatalogUtility::makeProductId(
+                    $idProduct,
+                    $idProductAttribute
+                ),
+            ],
             'num_items' => pSQL($quantity),
         ];
 
@@ -360,7 +375,10 @@ class EventDataProvider
         $order = $this->module->psVersionIs17 ? $params['order'] : $params['objOrder'];
         $productList = [];
         foreach ($order->getProducts() as $product) {
-            $productList[] = $product['id_product'];
+            $productList[] = ProductCatalogUtility::makeProductId(
+                $product['id_product'],
+                $product['id_product_attribute']
+            );
         }
 
         $type = 'Purchase';
@@ -495,11 +513,11 @@ class EventDataProvider
             $idProductAttribute = 0;
         }
 
-        $psProductId = ProductCatalogUtility::makeProductId($productId, $idProductAttribute);
-
         return [
             'content_type' => self::PRODUCT_TYPE,
-            'content_ids' => [$psProductId],
+            'content_ids' => [
+                ProductCatalogUtility::makeProductId($productId, $idProductAttribute),
+            ],
             'custom_properties' => [
                 'custom_attributes' => $attributes,
             ],

--- a/classes/Provider/EventDataProvider.php
+++ b/classes/Provider/EventDataProvider.php
@@ -218,7 +218,7 @@ class EventDataProvider
             'content_name' => \Tools::replaceAccentedChars($category->name) . ' ' . $this->locale,
             'content_category' => \Tools::replaceAccentedChars($breadcrumb),
             'content_type' => self::CATEGORY_TYPE,
-            'content_ids' => array_column($prods, 'id_product'),
+            'content_ids' => $prods ? array_column($prods, 'id_product') : null,
         ];
 
         return [

--- a/classes/Provider/EventDataProvider.php
+++ b/classes/Provider/EventDataProvider.php
@@ -388,6 +388,7 @@ class EventDataProvider
             'order_id' => $order->id,
             'currency' => $this->getCurrency(),
             'content_ids' => $productList,
+            'content_type' => self::PRODUCT_TYPE,
             'value' => (float) ($order->total_paid_tax_excl),
         ];
 


### PR DESCRIPTION
Fixes

![image](https://user-images.githubusercontent.com/6768917/116587979-ea479f80-a912-11eb-9bfc-24ed4e3eaf1c.png)

And make sure that all content_ids have IDs in the format `productID-productAttributeID`. These events were only sending the product ID:
* view categories
* order confirmation
* add to cart
* customize product