### PR TITLE
Bring back compliancy with PS Accounts v3

### DIFF
--- a/_dev/src/components/warning/module-action-needed.vue
+++ b/_dev/src/components/warning/module-action-needed.vue
@@ -85,9 +85,9 @@ export default defineComponent({
   },
   computed: {
     actionNeeded() {
-      /* if (this.moduleVersionCheck.needsUpgrade) {
+      if (this.moduleVersionCheck.needsUpgrade) {
         return 'Upgrade';
-      } */
+      }
       if (this.moduleName === 'Accounts') {
         // No need to check ps_accounts is enabled & installed,
         // as it is handled by the libraries

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "prestashop/module-lib-faq": "^1.0",
         "prestashop/module-lib-service-container": "^1.3",
         "segmentio/analytics-php": "^1.5",
-        "sentry/sentry": "^1.11.0"
+        "sentry/sentry": "^1.11.0",
+        "prestashop/prestashop-accounts-auth": "^2.3"
     },
     "require-dev": {
         "prestashop/php-dev-tools": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "64d13c5c40969a2b8eb976de94c2ee64",
+    "content-hash": "25fb1bd2cbac0d02726eb069e960bb28",
     "packages": [
         {
             "name": "facebook/graph-sdk",
@@ -264,6 +264,79 @@
             "time": "2014-10-12T19:18:40+00:00"
         },
         {
+            "name": "lcobucci/jwt",
+            "version": "3.4.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lcobucci/jwt.git",
+                "reference": "511629a54465e89a31d3d7e4cf0935feab8b14c1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/511629a54465e89a31d3d7e4cf0935feab8b14c1",
+                "reference": "511629a54465e89a31d3d7e4cf0935feab8b14c1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "ext-openssl": "*",
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "mikey179/vfsstream": "~1.5",
+                "phpmd/phpmd": "~2.2",
+                "phpunit/php-invoker": "~1.1",
+                "phpunit/phpunit": "^5.7 || ^7.3",
+                "squizlabs/php_codesniffer": "~2.3"
+            },
+            "suggest": {
+                "lcobucci/clock": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Lcobucci\\JWT\\": "src"
+                },
+                "files": [
+                    "compat/class-aliases.php",
+                    "compat/json-exception-polyfill.php",
+                    "compat/lcobucci-clock-polyfill.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Luís Otávio Cobucci Oblonczyk",
+                    "email": "lcobucci@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to work with JSON Web Token and JSON Web Signature",
+            "keywords": [
+                "JWS",
+                "jwt"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/lcobucci",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/lcobucci",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2021-02-16T09:40:01+00:00"
+        },
+        {
             "name": "paragonie/random_compat",
             "version": "v2.0.20",
             "source": {
@@ -366,6 +439,111 @@
                 "type"
             ],
             "time": "2020-07-20T17:29:33+00:00"
+        },
+        {
+            "name": "phpseclib/phpseclib",
+            "version": "2.0.31",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpseclib/phpseclib.git",
+                "reference": "233a920cb38636a43b18d428f9a8db1f0a1a08f4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/233a920cb38636a43b18d428f9a8db1f0a1a08f4",
+                "reference": "233a920cb38636a43b18d428f9a8db1f0a1a08f4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phing/phing": "~2.7",
+                "phpunit/phpunit": "^4.8.35|^5.7|^6.0|^9.4",
+                "squizlabs/php_codesniffer": "~2.0"
+            },
+            "suggest": {
+                "ext-gmp": "Install the GMP (GNU Multiple Precision) extension in order to speed up arbitrary precision integer arithmetic operations.",
+                "ext-libsodium": "SSH2/SFTP can make use of some algorithms provided by the libsodium-php extension.",
+                "ext-mcrypt": "Install the Mcrypt extension in order to speed up a few other cryptographic operations.",
+                "ext-openssl": "Install the OpenSSL extension in order to speed up a wide variety of cryptographic operations."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "phpseclib/bootstrap.php"
+                ],
+                "psr-4": {
+                    "phpseclib\\": "phpseclib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jim Wigginton",
+                    "email": "terrafrost@php.net",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Patrick Monnerat",
+                    "email": "pm@datasphere.ch",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Andreas Fischer",
+                    "email": "bantu@phpbb.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Hans-Jürgen Petrich",
+                    "email": "petrich@tronic-media.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Graham Campbell",
+                    "email": "graham@alt-three.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP Secure Communications Library - Pure-PHP implementations of RSA, AES, SSH2, SFTP, X.509 etc.",
+            "homepage": "http://phpseclib.sourceforge.net",
+            "keywords": [
+                "BigInteger",
+                "aes",
+                "asn.1",
+                "asn1",
+                "blowfish",
+                "crypto",
+                "cryptography",
+                "encryption",
+                "rsa",
+                "security",
+                "sftp",
+                "signature",
+                "signing",
+                "ssh",
+                "twofish",
+                "x.509",
+                "x509"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/terrafrost",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/phpseclib",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpseclib/phpseclib",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-04-06T13:56:45+00:00"
         },
         {
             "name": "prestashop/circuit-breaker",
@@ -562,6 +740,48 @@
                 "prestashop"
             ],
             "time": "2020-10-21T08:35:58+00:00"
+        },
+        {
+            "name": "prestashop/prestashop-accounts-auth",
+            "version": "v2.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PrestaShopCorp/prestashop_accounts_auth.git",
+                "reference": "1337ce5fd0a43fa7b14a4dcd506a768a8b52ea59"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PrestaShopCorp/prestashop_accounts_auth/zipball/1337ce5fd0a43fa7b14a4dcd506a768a8b52ea59",
+                "reference": "1337ce5fd0a43fa7b14a4dcd506a768a8b52ea59",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/guzzle": "~5.0",
+                "lcobucci/jwt": "^3.3",
+                "php": ">=5.6",
+                "phpseclib/phpseclib": "^2.0",
+                "sentry/sentry": "^1.0",
+                "symfony/dotenv": "^3.4"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.16",
+                "fzaninotto/faker": "^1.9",
+                "phpunit/phpunit": "^5.7",
+                "prestashop/php-dev-tools": "3.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PrestaShop\\AccountsAuth\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PrestaShop Accounts composer library",
+            "time": "2021-04-26T10:28:22+00:00"
         },
         {
             "name": "prestashop/prestashop-accounts-installer",
@@ -1166,6 +1386,72 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-24T10:57:07+00:00"
+        },
+        {
+            "name": "symfony/dotenv",
+            "version": "v3.4.47",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/dotenv.git",
+                "reference": "1022723ac4f56b001d99691d96c6025dbf1404f1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/dotenv/zipball/1022723ac4f56b001d99691d96c6025dbf1404f1",
+                "reference": "1022723ac4f56b001d99691d96c6025dbf1404f1",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8"
+            },
+            "require-dev": {
+                "symfony/process": "^3.4.2|^4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Dotenv\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Registers environment variables from a .env file",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "dotenv",
+                "env",
+                "environment"
+            ],
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>ps_facebook</name>
     <displayName><![CDATA[PS Facebook]]></displayName>
-    <version><![CDATA[1.9.1]]></version>
+    <version><![CDATA[1.9.2]]></version>
     <description><![CDATA[PS Facebook gives you all the tools you need to successfully sell and market across Facebook and Instagram. Discover new opportunities to help you scale and grow your business, and manage all your Facebook accounts and products from one place.]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <tab><![CDATA[advertising_marketing]]></tab>

--- a/controllers/admin/AdminPsfacebookModuleController.php
+++ b/controllers/admin/AdminPsfacebookModuleController.php
@@ -18,6 +18,7 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */
 
+use PrestaShop\AccountsAuth\Presenter\PsAccountsPresenter;
 use PrestaShop\Module\PrestashopFacebook\Adapter\ConfigurationAdapter;
 use PrestaShop\Module\PrestashopFacebook\Config\Config;
 use PrestaShop\Module\PrestashopFacebook\Config\Env;
@@ -91,21 +92,12 @@ class AdminPsfacebookModuleController extends ModuleAdminController
             ]);
         }
 
-        try {
-            $psAccountsService = $this->module->getService(PsAccounts::class)->getPsAccountsService();
-            $psAccountsToken = $psAccountsService->getOrRefreshToken();
-            $psAccountShopId = $psAccountsService->getShopUuidV4();
-        } catch (Exception $e) {
-            $psAccountsToken = '';
-            $psAccountShopId = null;
-        }
+        $psAccountsData = $this->getPsAccountsData();
 
         Media::addJsDef([
             // (object) cast is useful for the js when the array is empty
-            'contextPsAccounts' => (object) $this->module->getService(PsAccounts::class)
-                ->getPsAccountsPresenter()
-                ->present($this->module->name),
-            'psAccountsToken' => $psAccountsToken,
+            'contextPsAccounts' => (object) $this->getPsAccountsContext(),
+            'psAccountsToken' => $psAccountsData['psAccountsToken'],
             'defaultCategory' => $this->shopRepository->getDefaultCategoryShop(),
             'psAccountShopInConflict' => $this->multishopDataProvider->isCurrentShopInConflict($this->context->shop),
             'psFacebookAppId' => $this->env->get('PSX_FACEBOOK_APP_ID'),
@@ -327,7 +319,7 @@ class AdminPsfacebookModuleController extends ModuleAdminController
             'email' => $this->context->employee->email,
             'psVersion' => _PS_VERSION_,
             'moduleVersion' => $this->module->version,
-            'psAccountShopId' => $psAccountShopId,
+            'psAccountShopId' => $psAccountsData['psAccountShopId'],
             'psEventBusVersionCheck' => $this->moduleUpgradePresenter->generateModuleDependencyVersionCheck(
                 'ps_eventbus',
                 Config::REQUIRED_PS_EVENTBUS_VERSION
@@ -352,6 +344,129 @@ class AdminPsfacebookModuleController extends ModuleAdminController
         $access_token = Tools::getValue(Config::PS_FACEBOOK_USER_ACCESS_TOKEN);
         if (!empty($access_token)) {
             $this->configurationAdapter->updateValue(Config::PS_FACEBOOK_USER_ACCESS_TOKEN, $access_token);
+        }
+    }
+
+    private function getPsAccountsData()
+    {
+        $data = [
+            'psAccountsToken' => '',
+            'psAccountShopId' => null,
+        ];
+
+        $useNewLib = false;
+        $moduleName = 'ps_accounts';
+        $moduleInstance = null;
+        if (Module::isInstalled($moduleName)) {
+            $moduleInstance = Module::getInstanceByName($moduleName);
+            if ($moduleInstance !== false) {
+                $currentVersion = $moduleInstance->version;
+
+                $useNewLib = version_compare(
+                    $currentVersion,
+                    '4.0.0',
+                    '<'
+                );
+            }
+        }
+
+        if ($useNewLib) {
+            try {
+                $psAccountsService = $this->module->getService(PsAccounts::class)->getPsAccountsService();
+                $data['psAccountsToken'] = $psAccountsService->getOrRefreshToken();
+                $data['psAccountShopId'] = $psAccountsService->getShopUuidV4();
+            } catch (Exception $e) {}
+
+            return $data;
+        }
+
+        $psAccountsService = new PsAccountsService();
+        $data['psAccountsToken'] = method_exists($psAccountsService, 'getOrRefreshToken') ? $psAccountsService->getOrRefreshToken() : '';
+        $data['psAccountShopId'] = $psAccountsService->getShopUuidV4();
+        return $data;
+    }
+
+    private function getPsAccountsContext()
+    {
+        $useNewLib = false;
+        $moduleName = 'ps_accounts';
+        $moduleInstance = null;
+        if (Module::isInstalled($moduleName)) {
+            $moduleInstance = Module::getInstanceByName($moduleName);
+            if ($moduleInstance !== false) {
+                $currentVersion = $moduleInstance->version;
+
+                $useNewLib = version_compare(
+                    $currentVersion,
+                    '4.0.0',
+                    '<'
+                );
+            }
+        }
+
+        if ($useNewLib) {
+            return $this->module->getService(PsAccounts::class)
+                ->getPsAccountsPresenter()
+                ->present($this->module->name);
+        }
+
+        $this->psAccountsEnvVarHotFix();
+        $psAccountPresenter = new PsAccountsPresenter($this->module->name);
+        return $this->psAccountsHotFix($psAccountPresenter->present());
+    }
+
+
+    /**
+     * Quickfix for multishop with PS Accounts.
+     * The shop in the Context class is always defined, even if multistore. This means the multistore selector
+     * is never displayed at the moment.
+     * TODO : Move in https://github.com/PrestaShopCorp/prestashop_accounts_vue_components
+     */
+    private function psAccountsHotFix(array $presentedData)
+    {
+        if (!isset($presentedData['shops'])) {
+            return;
+        }
+
+        foreach ($presentedData['shops'] as &$shopGroup) {
+            foreach ($shopGroup['shops'] as &$shop) {
+                $shop['url'] = $this->context->link->getAdminLink(
+                    'AdminModules',
+                    true,
+                    [],
+                    [
+                        'configure' => $this->module->name,
+                        'setShopContext' => 's-' . $shop['id'],
+                    ]
+                );
+            }
+        }
+
+        $presentedData['isShopContext'] = Shop::getContext() === Shop::CONTEXT_SHOP;
+
+        return $presentedData;
+    }
+
+    /**
+     * Quickfix for multishop with PS Accounts.
+     * Some env var are used without being checked first, and this may break the whole script execution if the version installed is old.
+     * We set them with a default value until these checks exist.
+     */
+    private function psAccountsEnvVarHotFix()
+    {
+        $envVarUsed = [
+            'ACCOUNTS_SVC_API_URL',
+            'BILLING_SVC_API_URL',
+            'SENTRY_CREDENTIALS',
+            'SSO_RESEND_VERIFICATION_EMAIL',
+            'ACCOUNTS_SVC_UI_URL',
+            'SSO_MANAGE_ACCOUNT',
+        ];
+
+        foreach ($envVarUsed as $envVar) {
+            if (!isset($_ENV[$envVar])) {
+                $_ENV[$envVar] = null;
+            }
         }
     }
 }

--- a/controllers/admin/AdminPsfacebookModuleController.php
+++ b/controllers/admin/AdminPsfacebookModuleController.php
@@ -19,6 +19,7 @@
  */
 
 use PrestaShop\AccountsAuth\Presenter\PsAccountsPresenter;
+use PrestaShop\AccountsAuth\Service\PsAccountsService;
 use PrestaShop\Module\PrestashopFacebook\Adapter\ConfigurationAdapter;
 use PrestaShop\Module\PrestashopFacebook\Config\Config;
 use PrestaShop\Module\PrestashopFacebook\Config\Env;
@@ -365,7 +366,7 @@ class AdminPsfacebookModuleController extends ModuleAdminController
                 $useNewLib = version_compare(
                     $currentVersion,
                     '4.0.0',
-                    '<'
+                    '>='
                 );
             }
         }
@@ -375,7 +376,8 @@ class AdminPsfacebookModuleController extends ModuleAdminController
                 $psAccountsService = $this->module->getService(PsAccounts::class)->getPsAccountsService();
                 $data['psAccountsToken'] = $psAccountsService->getOrRefreshToken();
                 $data['psAccountShopId'] = $psAccountsService->getShopUuidV4();
-            } catch (Exception $e) {}
+            } catch (Exception $e) {
+            }
 
             return $data;
         }
@@ -383,6 +385,7 @@ class AdminPsfacebookModuleController extends ModuleAdminController
         $psAccountsService = new PsAccountsService();
         $data['psAccountsToken'] = method_exists($psAccountsService, 'getOrRefreshToken') ? $psAccountsService->getOrRefreshToken() : '';
         $data['psAccountShopId'] = $psAccountsService->getShopUuidV4();
+
         return $data;
     }
 
@@ -399,7 +402,7 @@ class AdminPsfacebookModuleController extends ModuleAdminController
                 $useNewLib = version_compare(
                     $currentVersion,
                     '4.0.0',
-                    '<'
+                    '>='
                 );
             }
         }
@@ -412,9 +415,9 @@ class AdminPsfacebookModuleController extends ModuleAdminController
 
         $this->psAccountsEnvVarHotFix();
         $psAccountPresenter = new PsAccountsPresenter($this->module->name);
+
         return $this->psAccountsHotFix($psAccountPresenter->present());
     }
-
 
     /**
      * Quickfix for multishop with PS Accounts.

--- a/ps_facebook.php
+++ b/ps_facebook.php
@@ -150,7 +150,7 @@ class Ps_facebook extends Module
     {
         $this->name = 'ps_facebook';
         $this->tab = 'advertising_marketing';
-        $this->version = '1.9.1';
+        $this->version = '1.9.2';
         $this->author = 'PrestaShop';
         $this->need_instance = 0;
         $this->module_key = '860395eb54512ec72d98615805274591';


### PR DESCRIPTION
It appears the module cannot work with shops that still use PS Accounts v3.

This PR allows the BO to be loaded in this case by reusing the old lib. Reverts partially #350 