### PR TITLE
Fix missing id_product_attribute on Order Confirmation page

### DIFF
--- a/classes/Provider/EventDataProvider.php
+++ b/classes/Provider/EventDataProvider.php
@@ -373,7 +373,7 @@ class EventDataProvider
         /** @var Order $order */
         $order = $this->module->psVersionIs17 ? $params['order'] : $params['objOrder'];
         $productList = [];
-        foreach ($order->getProducts() as $product) {
+        foreach ($order->getCartProducts() as $product) {
             $productList[] = ProductCatalogUtility::makeProductId(
                 $product['id_product'],
                 $product['id_product_attribute']


### PR DESCRIPTION
Reported by @RomainBocheux 

![image](https://user-images.githubusercontent.com/6768917/118635682-c538a500-b7cb-11eb-84b6-8389fe599a45.png)
