### PR TITLE
Pixel - Make sure products with quantity are sent in stock

### DIFF
--- a/classes/Provider/EventDataProvider.php
+++ b/classes/Provider/EventDataProvider.php
@@ -185,7 +185,10 @@ class EventDataProvider
         $this->context->smarty->assign(
             [
                 'retailer_item_id' => $fbProductId,
-                'product_availability' => $this->availabilityProvider->getProductAvailability((int) $product['id_product']),
+                'product_availability' => $this->availabilityProvider->getProductAvailability(
+                    (int) $product['id_product'],
+                    (int) $product['id_product_attribute']
+                ),
                 'item_group_id' => $category,
             ]
         );

--- a/classes/Provider/ProductAvailabilityProvider.php
+++ b/classes/Provider/ProductAvailabilityProvider.php
@@ -22,20 +22,26 @@ namespace PrestaShop\Module\PrestashopFacebook\Provider;
 
 use FacebookAds\Object\Values\ProductItemAvailabilityValues;
 use Product;
+use StockAvailable;
 
 class ProductAvailabilityProvider implements ProductAvailabilityProviderInterface
 {
     /**
      * @param int $productId
+     * @param int $productAttributeId
      *
      * @return string
      *
      * @throws \PrestaShopDatabaseException
      * @throws \PrestaShopException
      */
-    public function getProductAvailability($productId)
+    public function getProductAvailability($productId, $productAttributeId)
     {
         $product = new Product($productId);
+
+        if ((int) StockAvailable::getQuantityAvailableByProduct($productId, $productAttributeId)) {
+            return ProductItemAvailabilityValues::IN_STOCK;
+        }
 
         switch ($product->out_of_stock) {
             case 1:
@@ -46,7 +52,7 @@ class ProductAvailabilityProvider implements ProductAvailabilityProviderInterfac
                 return $isAvailable ? ProductItemAvailabilityValues::AVAILABLE_FOR_ORDER : ProductItemAvailabilityValues::OUT_OF_STOCK;
             case 0:
             default:
-                return ProductItemAvailabilityValues::DISCONTINUED;
+                return ProductItemAvailabilityValues::OUT_OF_STOCK;
         }
     }
 }

--- a/classes/Provider/ProductAvailabilityProviderInterface.php
+++ b/classes/Provider/ProductAvailabilityProviderInterface.php
@@ -27,5 +27,5 @@ interface ProductAvailabilityProviderInterface
      *
      * @return string
      */
-    public function getProductAvailability($productId);
+    public function getProductAvailability($productId, $productAttributeId);
 }

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>ps_facebook</name>
     <displayName><![CDATA[PS Facebook]]></displayName>
-    <version><![CDATA[1.9.2]]></version>
+    <version><![CDATA[1.10.0]]></version>
     <description><![CDATA[PS Facebook gives you all the tools you need to successfully sell and market across Facebook and Instagram. Discover new opportunities to help you scale and grow your business, and manage all your Facebook accounts and products from one place.]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <tab><![CDATA[advertising_marketing]]></tab>

--- a/ps_facebook.php
+++ b/ps_facebook.php
@@ -150,7 +150,7 @@ class Ps_facebook extends Module
     {
         $this->name = 'ps_facebook';
         $this->tab = 'advertising_marketing';
-        $this->version = '1.9.2';
+        $this->version = '1.10.0';
         $this->author = 'PrestaShop';
         $this->need_instance = 0;
         $this->module_key = '860395eb54512ec72d98615805274591';


### PR DESCRIPTION
Some merchants reported that products are reported as out-of-stock although the quantity is above zero on PrestaShop.

This PR improve the stock status reported by Pixel.

## On version 1.9 and below:

### Product is in stock (can be ordered)

![image](https://user-images.githubusercontent.com/6768917/118952051-85042e80-b953-11eb-9026-6c6ef073f055.png)

### But Pixel says it is out of stock

![image](https://user-images.githubusercontent.com/6768917/118952001-7ae23000-b953-11eb-8c3c-4e468e4570f3.png)



