### PR TITLE
track ViewCategory as trackCustom

### DIFF
--- a/classes/Handler/PixelHandler.php
+++ b/classes/Handler/PixelHandler.php
@@ -67,6 +67,10 @@ class PixelHandler
         $eventType = false;
         if (isset($params['event_type'])) {
             $eventType = $params['event_type'];
+            
+            if ($eventType = 'ViewCategory') {
+                $track = 'trackCustom';
+            }
         }
         if (isset($params['user'])) {
             $userData = $params['user'];


### PR DESCRIPTION
As per Meta's dev docs, ViewCategory is not a Standard event and should be tracked as trackCustom. List of Standard Event can be found here: <https://developers.facebook.com/docs/meta-pixel/reference#standard-events>