### PR TITLE
Fix originalEvent undefined error and unused variable selectedAttribute

### DIFF
--- a/views/js/front/conversion-api.js
+++ b/views/js/front/conversion-api.js
@@ -21,7 +21,6 @@ $(document).ready(function () {
         if (params.eventType === 'updatedProductCombination') {
             var productId = $('input[name="id_product"]').val();
             var $productAttributes = $(params.event.handleObj.selector);
-            var selectedAttribute = $(params.event.originalEvent.srcElement);
             var attributes = [];
             $productAttributes.each(function (key, attribute) {
                 if ($(attribute).is("input") && !$(attribute).is(':checked')) {


### PR DESCRIPTION
When updating the product, the event "updateProduct" is emitted.
This event is listened by the module but an error is thrown.
```
Uncaught TypeError: params.event.originalEvent is undefined
    <anonymous> conversion-api.js:25
```

The `event` variable is not a jQuery event object, therefore, there is no `originalEvent` property.
Moreover, the `selectedAttribute` variable that is set base upon the originalEvent undefined property is not even used.

Therefore I propose to simply add a comment to disable this line of code.
I did not remove it for the sake of whatever reasons this line was here and to not overstep.