### PR TITLE
Controller not defined for webservices requests

### DIFF
--- a/classes/Dispatcher/EventDispatcher.php
+++ b/classes/Dispatcher/EventDispatcher.php
@@ -77,6 +77,7 @@ class EventDispatcher
     public function dispatch($name, array $params)
     {
         // Events are related to actions on the shop, not the back office
+        /** @var \Controller|null $controller */
         $controller = $this->context->controller;
         if (!$controller || !in_array($controller->controller_type, ['front', 'modulefront'])) {
             return;

--- a/classes/Dispatcher/EventDispatcher.php
+++ b/classes/Dispatcher/EventDispatcher.php
@@ -77,7 +77,8 @@ class EventDispatcher
     public function dispatch($name, array $params)
     {
         // Events are related to actions on the shop, not the back office
-        if (!in_array($this->context->controller->controller_type, ['front', 'modulefront'])) {
+        $controller = $this->context->controller;
+        if (!$controller || !in_array($controller->controller_type, ['front', 'modulefront'])) {
             return;
         }
 


### PR DESCRIPTION
The error is reproducible with a vanilla PrestaShop 1.7.8.6 and the Facebook module (who is installed during the PrestaShop install) not configured. 

Step to reproduce:
- Enable PrestaShop's webservice in Advanced Parameters > Webservice
- Add a new webservice key with at least Cart permissions
- Try to create a cart with the webservice

```
curl --location --request POST 'http://my-private-url/api/carts' \
--header 'Authorization: Basic BASE64_ENCODED_PRESTASHOP_WEBSERVICE_KEY' \
--header 'Content-Type: application/xml' \
--data-raw '<prestashop>
  <cart>
    <id_address_delivery>1</id_address_delivery>
    <id_address_invoice>1</id_address_invoice>
    <id_currency>1</id_currency>
    <id_customer>1</id_customer>
    <id_guest></id_guest>
    <id_lang>1</id_lang>
    <id_shop_group></id_shop_group>
    <id_shop>1</id_shop>
    <id_carrier></id_carrier>
    <recyclable></recyclable>
    <gift></gift>
    <gift_message></gift_message>
    <mobile_theme></mobile_theme>
    <secure_key>1bc98370e75f9e2c67b45272b62cd6d1</secure_key>
    <allow_seperated_package></allow_seperated_package>
    <associations>
      <cart_rows>
        <cart_row>
          <id_product>1</id_product>
          <id_product_attribute>1</id_product_attribute>
          <id_address_delivery></id_address_delivery>
          <id_customization></id_customization>
          <quantity>1</quantity>
        </cart_row>
      </cart_rows>
    </associations>
  </cart>
</prestashop>'
```


The response code of the request is: **500 Internal Server Error**

The error message:
[PHP Notice #8] Trying to get property 'controller_type' of non-object (/var/www/html/modules/ps_facebook/classes/Dispatcher/EventDispatcher.php, line 80)
