### PR TITLE
Warning message file_exists() in php 7.4

### DIFF
--- a/classes/Handler/PixelHandler.php
+++ b/classes/Handler/PixelHandler.php
@@ -95,7 +95,7 @@ class PixelHandler
 
         $this->context->smarty->assign($smartyVariables);
 
-        $this->templateBuffer->add($this->module->display($this->module->getfilePath(), '/views/templates/hook/header.tpl'));
+        $this->templateBuffer->add($this->module->display($this->module->getfilePath(), 'views/templates/hook/header.tpl'));
     }
 
     /**


### PR DESCRIPTION
Got warning message in php 7.4
Got error 'PHP message: PHP Warning:  file_exists(): open_basedir restriction in effect. File(/views/templates/hook/header.tpl) is not within the allowed path(s): (/var/www/vhosts/XXXXX/:/tmp/:/usr/share/php/:/var/www/vhosts/system/XXXX/opcache/) in /XXX/classes/module/Module.php on line 2509'