### PR TITLE
Forgot checking the initial value as number

### DIFF
--- a/_dev/src/components/catalog/report-details/prevalidation-table.vue
+++ b/_dev/src/components/catalog/report-details/prevalidation-table.vue
@@ -245,10 +245,10 @@ export default defineComponent({
           acc[previousIndex].l.push(language);
         } else {
           acc.push({
-            cover: (has_cover === 1),
-            d: (has_description_or_short_description === 1),
-            isbn: (has_manufacturer_or_ean_or_upc_or_isbn === 1),
-            price: (has_price_tax_excl === 1),
+            cover: (+has_cover === 1),
+            d: (+has_description_or_short_description === 1),
+            isbn: (+has_manufacturer_or_ean_or_upc_or_isbn === 1),
+            price: (+has_price_tax_excl === 1),
             id_product,
             id_product_attribute,
             ...vals,


### PR DESCRIPTION
Following #409, the initial value had to be checked as a number but was not included in the PR