### PR TITLE
Reset Sentry DSN and filter exceptions sent

### DIFF
--- a/classes/Config/Config.php
+++ b/classes/Config/Config.php
@@ -59,7 +59,7 @@ class Config
     public const PSX_FACEBOOK_API_URL = 'https://facebook-api.psessentials.net';
     public const PSX_FACEBOOK_UI_URL = 'https://facebook.psessentials.net';
     public const PSX_FACEBOOK_APP_ID = '726899634800479';
-    public const PSX_FACEBOOK_SENTRY_CREDENTIALS = 'https://4252ed38f42f4f7285c7932337fe77a2@o298402.ingest.sentry.io/5531852';
+    public const PSX_FACEBOOK_SENTRY_CREDENTIALS = 'https://c5dacaa8aca74c458179b113b646774c@o298402.ingest.sentry.io/5531852';
     public const PSX_FACEBOOK_SEGMENT_API_KEY = 'vgBkyeNDK7tQwgxrxoVUGRMNGTUATiPw';
 
     /** @see https://developers.facebook.com/docs/marketing-api/error-reference */

--- a/classes/Handler/ErrorHandler/ModuleFilteredRavenClient.php
+++ b/classes/Handler/ErrorHandler/ModuleFilteredRavenClient.php
@@ -98,12 +98,10 @@ class ModuleFilteredRavenClient extends Raven_Client
      */
     private function isErrorInApp(array $data)
     {
-        $atLeastOneFileIsInApp = false;
-        foreach ($data['stacktrace']['frames'] as $frame) {
-            $atLeastOneFileIsInApp = $atLeastOneFileIsInApp || ((isset($frame['in_app']) && $frame['in_app']));
-        }
+        $lastFrame = end($data['stacktrace']['frames']);
+        $lastFrameIsInApp = (isset($lastFrame['in_app']) && $lastFrame['in_app']);
 
-        return $atLeastOneFileIsInApp;
+        return $lastFrameIsInApp;
     }
 
     /**


### PR DESCRIPTION
We receive too many errors from the Facebook project, because of errors related to the core.

This PR sets a filter so we keep at the moment exceptions thrown from our code.