### PR TITLE
Improve messenger chat activation

### DIFF
--- a/_dev/src/components/features/available-feature.vue
+++ b/_dev/src/components/features/available-feature.vue
@@ -64,11 +64,35 @@ export default defineComponent({
       type: Object,
       required: true,
     },
+    updateFeatureRoute: {
+      type: String,
+      required: false,
+      default: global.psFacebookUpdateFeatureRoute,
+    },
   },
   methods: {
     onSales(name) {
       this.$segment.track(`Add CTA - ${name}`, {
         module: 'ps_facebook',
+      });
+
+      fetch(this.updateFeatureRoute, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json', Accept: 'application/json'},
+        body: JSON.stringify({featureName: this.name, enabled: true}),
+      }).then((res) => {
+        if (!res.ok) {
+          throw new Error(res.statusText || res.status);
+        }
+        return res.json();
+      }).then((res) => {
+        if (res.success === false) {
+          throw new Error('failed to update feature');
+        } else {
+          this.$emit('onToggleSwitch', this.name, true);
+        }
+      }).catch((error) => {
+        console.error(error);
       });
     },
   },

--- a/_dev/src/views/integrate.vue
+++ b/_dev/src/views/integrate.vue
@@ -70,6 +70,7 @@
             :name="featureName"
             :key="featureName"
             :manage-route="manageRoute"
+            @onToggleSwitch="onToggleSwitch"
           />
         </feature-list>
       </div>

--- a/_dev/src/views/integrate.vue
+++ b/_dev/src/views/integrate.vue
@@ -163,6 +163,7 @@ export default defineComponent({
       required: false,
       default: () => ({
         default: `https://www.facebook.com/facebook_business_extension?app_id=${global.psFacebookAppId}&external_business_id=${global.psFacebookExternalBusinessId}`,
+        messenger_chat: `https://business.facebook.com/latest/inbox/settings/chat_plugin?asset_id=${global.contextPsFacebook?.page?.id}`,
         page_cta: `https://www.facebook.com/${global.contextPsFacebook?.page?.id}`,
         view_message_url: `https://business.facebook.com/latest/inbox/all?asset_id=${global.contextPsFacebook?.page?.id}`,
       }),

--- a/classes/Config/Config.php
+++ b/classes/Config/Config.php
@@ -47,6 +47,7 @@ class Config
     public const PS_FACEBOOK_PRODUCT_SYNC_ON = 'PS_FACEBOOK_PRODUCT_SYNC_ON';
 
     public const AVAILABLE_FBE_FEATURES = ['messenger_chat', 'page_cta', 'page_shop'/*, 'ig_shopping'*/];
+    public const CONFIGURABLE_FBE_FEATURES = ['messenger_chat'];
     public const FBE_FEATURES_REQUIRING_PRODUCT_SYNC = ['page_shop', 'ig_shopping'];
     public const FBE_FEATURE_CONFIGURATION = 'PS_FACEBOOK_FBE_FEATURE_CONFIG_';
 

--- a/classes/Handler/ConfigurationHandler.php
+++ b/classes/Handler/ConfigurationHandler.php
@@ -77,6 +77,10 @@ class ConfigurationHandler
             Config::PS_FACEBOOK_SUSPENSION_REASON,
         ];
 
+        foreach (Config::AVAILABLE_FBE_FEATURES as $featureName) {
+            $dataConfigurationKeys[] = Config::FBE_FEATURE_CONFIGURATION . $featureName;
+        }
+
         foreach ($dataConfigurationKeys as $key) {
             $this->configurationAdapter->deleteByName($key);
         }

--- a/classes/Manager/FbeFeatureManager.php
+++ b/classes/Manager/FbeFeatureManager.php
@@ -60,6 +60,12 @@ class FbeFeatureManager
 
         if ($featureName == 'messenger_chat') {
             unset($featureConfiguration->default_locale);
+
+            // Todo: Add domain
+            // @see https://developers.facebook.com/docs/facebook-business-extension/fbe/reference#FBEMessengerChatConfigData
+            $featureConfiguration->domains = [
+                \Tools::getShopDomainSsl(true),
+            ];
         }
 
         $featureConfiguration->enabled = (bool) $state;

--- a/classes/Manager/FbeFeatureManager.php
+++ b/classes/Manager/FbeFeatureManager.php
@@ -52,7 +52,7 @@ class FbeFeatureManager
         $featureConfiguration = $this->configurationAdapter->get(Config::FBE_FEATURE_CONFIGURATION . $featureName);
         $externalBusinessId = $this->configurationAdapter->get(Config::PS_FACEBOOK_EXTERNAL_BUSINESS_ID);
 
-        if (!$featureConfiguration) {
+        if (!$featureConfiguration && !in_array($featureName, Config::CONFIGURABLE_FBE_FEATURES)) {
             return false;
         }
 
@@ -61,8 +61,7 @@ class FbeFeatureManager
         if ($featureName == 'messenger_chat') {
             unset($featureConfiguration->default_locale);
 
-            // Todo: Add domain
-            // @see https://developers.facebook.com/docs/facebook-business-extension/fbe/reference#FBEMessengerChatConfigData
+            /* @see https://developers.facebook.com/docs/facebook-business-extension/fbe/reference#FBEMessengerChatConfigData */
             $featureConfiguration->domains = [
                 \Tools::getShopDomainSsl(true),
             ];


### PR DESCRIPTION
On one of our shop, we were unable to see the messenger chat activated even if we spent some time on Facebook interface to configure it.

This PR:
* updates the redirection link so the merchant finds directly the proper page
* tries to enable messenger directly with a new API call
* add the current shop domain as authorized

https://developers.facebook.com/docs/facebook-business-extension/fbe/guides/business-configurations