### PR TITLE
Update behavior of component when Facebook is not connected

### DIFF
--- a/_dev/src/components/configuration/facebook-not-connected.vue
+++ b/_dev/src/components/configuration/facebook-not-connected.vue
@@ -17,53 +17,52 @@
  * International Registered Trademark & Property of PrestaShop SA
  *-->
 <template>
-  <b-overlay
-    :show="!active"
-    opacity="0.7"
-    no-fade
-  >
-    <b-card no-body>
-      <template v-slot:header>
-        <h3 class="d-inline">
-          {{ $t('configuration.facebook.notConnected.title') }}
-        </h3>
-      </template>
-      <b-card-body
-        class="pl-3 pt-3 pr-3"
+  <b-card no-body>
+    <template v-slot:header>
+      <h3 class="d-inline">
+        {{ $t('configuration.facebook.notConnected.title') }}
+      </h3>
+    </template>
+    <b-card-body
+      class="pl-3 pt-3 pr-3"
+    >
+      {{ $t('configuration.facebook.notConnected.intro') }}
+    </b-card-body>
+    <b-card-body class="pt-0 pl-3 pb-3 pr-3">
+      <b-button
+        :variant="active && canConnect ? 'primary' : 'outline-primary disabled'"
+        class="float-right ml-4 btn-with-spinner"
+        @click="onFbeOnboardClick"
+        :disabled="!active || !canConnect"
       >
-        {{ $t('configuration.facebook.notConnected.intro') }}
-      </b-card-body>
-      <b-card-body class="pt-0 pl-3 pb-3 pr-3">
-        <b-button
-          :variant="canConnect ? 'primary' : 'outline-primary disabled'"
-          class="float-right ml-4 btn-with-spinner"
-          @click="onFbeOnboardClick"
-          v-if="active"
-          :disabled="!canConnect"
-        >
+        <span :class="active && !canConnect ? 'hidden' : ''">
           {{ $t('configuration.facebook.notConnected.connectButton') }}
-        </b-button>
+        </span>
+        <div
+          v-if="active && !canConnect"
+          class="spinner"
+        />
+      </b-button>
 
-        <div class="logo mr-3">
-          <img
-            src="@/assets/facebook_logo.svg"
-            alt="colors"
-          >
-        </div>
+      <div class="logo mr-3">
+        <img
+          src="@/assets/facebook_logo.svg"
+          alt="colors"
+        >
+      </div>
 
-        <div class="description pr-2">
-          <div>
-            {{ $t('configuration.facebook.notConnected.description') }}
-            <br>
-            <p
-              class="facebook-not-connected-details small-text text-muted"
-              v-html="md2html($t('configuration.facebook.notConnected.details'))"
-            />
-          </div>
+      <div class="description pr-2">
+        <div>
+          {{ $t('configuration.facebook.notConnected.description') }}
+          <br>
+          <p
+            class="facebook-not-connected-details small-text text-muted"
+            v-html="md2html($t('configuration.facebook.notConnected.details'))"
+          />
         </div>
-      </b-card-body>
-    </b-card>
-  </b-overlay>
+      </div>
+    </b-card-body>
+  </b-card>
 </template>
 
 <script lang="ts">
@@ -120,6 +119,7 @@ export default defineComponent({
       height: 1.3rem !important;
       position: absolute;
       left: calc(50% - 0.6rem);
+      top: calc(50% - 0.6rem);
     }
   }
 

--- a/_dev/src/views/configuration.vue
+++ b/_dev/src/views/configuration.vue
@@ -74,8 +74,8 @@
           v-if="!facebookConnected"
           @onFbeOnboardClick="onFbeOnboardClick"
           class="m-3"
-          :active="psAccountsOnboarded"
-          :can-connect="cloudSyncSharingConsentGiven && !!dynamicExternalBusinessId"
+          :active="psAccountsOnboarded && cloudSyncSharingConsentGiven"
+          :can-connect="!!dynamicExternalBusinessId"
         />
         <facebook-connected
           v-else

--- a/_dev/stories/104-configuration-fb-not-connected.stories.ts
+++ b/_dev/stories/104-configuration-fb-not-connected.stories.ts
@@ -8,7 +8,22 @@ export default {
 const Template = (args: any, { argTypes }: any) => ({
   props: Object.keys(argTypes),
   components: { FacebookNotConnected },
-  template: '<facebook-not-connected @onFbeOnboardClick="onFbeOnboardClick" />',
+  template: '<facebook-not-connected @onFbeOnboardClick="onFbeOnboardClick" v-bind="$props" />',
 });
-export const Default:any = Template.bind({});
-Default.args = { };
+export const Inactive:any = Template.bind({});
+Inactive.args = {
+  active: false,
+  canConnect: false,
+};
+
+export const WaitingForBusinessId:any = Template.bind({});
+WaitingForBusinessId.args = {
+  active: true,
+  canConnect: false,
+};
+
+export const Ready:any = Template.bind({});
+Ready.args = {
+  active: true,
+  canConnect: true,
+};


### PR DESCRIPTION
*This PR is easier to review when ignoring white spaces*

* Brings back the spinner in the log-in button
* Removes the spinner on the card when the preliminary steps are not completed, because it was implying we were loading something from the shop or the API and the display of the card could change

![Marketing With Google](https://github.com/PrestaShopCorp/ps_facebook/assets/6768917/0dade305-cece-4680-92ab-e5c132c24904)
