### PR TITLE
Fix fatal error when updating discounts as guest

### DIFF
--- a/classes/Provider/EventDataProvider.php
+++ b/classes/Provider/EventDataProvider.php
@@ -271,6 +271,8 @@ class EventDataProvider
         $isDelete = $this->toolsAdapter->getValue('delete');
         $idProductAttribute = $this->toolsAdapter->getValue('id_product_attribute');
         $attributeGroups = $this->toolsAdapter->getValue('group');
+        $changesDiscount = $this->toolsAdapter->getValue('addDiscount')
+            || $this->toolsAdapter->getValue('deleteDiscount');
 
         if ($attributeGroups) {
             try {
@@ -283,7 +285,7 @@ class EventDataProvider
             }
         }
 
-        if ($action !== 'update') {
+        if ($action !== 'update' || $changesDiscount) {
             return false;
         }
         $type = 'AddToCart';


### PR DESCRIPTION
A fatal error is raised when a discount code is added or removed from cart (stack trace below):
```
[PrestaShopException]
Fatal error
at line 1182 in file classes/Tools.php
ToolsCore::displayError - [line 3612 - classes/Product.php]
ProductCore::getPriceStatic - [line 371 - modules/ps_facebook/classes/Repository/ProductRepository.php] - [11 Arguments]
PrestaShop\Module\PrestashopFacebook\Repository\ProductRepository->getSalePrice - [line 311 - modules/ps_facebook/classes/Provider/EventDataProvider.php] - [3 Arguments]
PrestaShop\Module\PrestashopFacebook\Provider\EventDataProvider->getAddToCartEventData - [line 132 - modules/ps_facebook/classes/Provider/EventDataProvider.php]
PrestaShop\Module\PrestashopFacebook\Provider\EventDataProvider->generateEventData - [line 90 - modules/ps_facebook/classes/Dispatcher/EventDispatcher.php] - [2 Arguments]
PrestaShop\Module\PrestashopFacebook\Dispatcher\EventDispatcher->dispatch - [line 368 - modules/ps_facebook/ps_facebook.php] - [2 Arguments]
Ps_facebook->hookActionCartSave - [line 1007 - classes/Hook.php] - [1 Arguments]
HookCore::coreCallHook - [line 431 - classes/Hook.php] - [3 Arguments]
```

This pull request makes sure to ignore any cart updates that are related to discounts (since no product ID is provided in those cases), and just take into account product quantity changes.