### PR TITLE
Improve error management when loading external business ID

### DIFF
--- a/_dev/src/store/modules/onboarding/actions.ts
+++ b/_dev/src/store/modules/onboarding/actions.ts
@@ -17,23 +17,26 @@ export default {
     }
     state.warmedUp = RequestState.PENDING;
 
-    await runIf(
-      !getters.GET_EXTERNAL_BUSINESS_ID,
-      dispatch(ActionsTypes.REQUEST_EXTERNAL_BUSINESS_ID),
-    );
-    await runIf(
-      !getters.IS_USER_ONBOARDED,
-      dispatch(ActionsTypes.REQUEST_ONBOARDING_STATE),
-    );
-    state.warmedUp = RequestState.SUCCESS;
+    try {
+      await runIf(
+        !getters.GET_EXTERNAL_BUSINESS_ID,
+        dispatch(ActionsTypes.REQUEST_EXTERNAL_BUSINESS_ID),
+      );
+      await runIf(
+        !getters.IS_USER_ONBOARDED,
+        dispatch(ActionsTypes.REQUEST_ONBOARDING_STATE),
+      );
+      state.warmedUp = RequestState.SUCCESS;
+    } catch {
+      state.warmedUp = RequestState.FAILED;
+    }
   },
 
-  async [ActionsTypes.REQUEST_EXTERNAL_BUSINESS_ID]({commit}): Promise<string> {
+  async [ActionsTypes.REQUEST_EXTERNAL_BUSINESS_ID]({commit}): Promise<void> {
     const json: {externalBusinessId: string} = await fetchShop(
       'RetrieveExternalBusinessId',
     );
     commit(MutationsTypes.SET_EXTERNAL_BUSINESS_ID, json.externalBusinessId);
-    return json.externalBusinessId;
   },
 
   async [ActionsTypes.REQUEST_ONBOARDING_STATE]({commit, state}) {

--- a/controllers/admin/AdminAjaxPsfacebookController.php
+++ b/controllers/admin/AdminAjaxPsfacebookController.php
@@ -196,6 +196,15 @@ class AdminAjaxPsfacebookController extends ModuleAdminController
                 $e->getCode(),
                 true
             );
+            $this->ajaxDie(
+                json_encode(
+                    [
+                        'success' => false,
+                        'message' => $e->getMessage(),
+                        'turnOn' => false,
+                    ]
+                )
+            );
 
             return;
         }
@@ -205,6 +214,16 @@ class AdminAjaxPsfacebookController extends ModuleAdminController
                 new FacebookOnboardException(
                     json_encode($response['message']),
                     FacebookOnboardException::FACEBOOK_RETRIEVE_EXTERNAL_BUSINESS_ID_EXCEPTION
+                )
+            );
+
+            $this->ajaxDie(
+                json_encode(
+                    [
+                        'success' => false,
+                        'message' => $response['message'],
+                        'turnOn' => false,
+                    ]
                 )
             );
 


### PR DESCRIPTION
When an exception occurs while retrieving the business ID, the response is empty and with an HTTP 200.

It also prevents the first page to be loaded. This PR fixes these issues.