### PR TITLE
Update data according to mockups on FB login & logout

### DIFF
--- a/_dev/src/components/catalog/summary/panel/verified-products.vue
+++ b/_dev/src/components/catalog/summary/panel/verified-products.vue
@@ -132,11 +132,11 @@ export default defineComponent({
       return [{
         title: this.$t('catalog.summaryPage.productCatalog.productVerification.reportCards.productsInCatalog'),
         description: this.$t('catalog.summaryPage.productCatalog.productVerification.reportCards.productsInCatalogDescription'),
-        value: this.productsInCatalog,
+        value: this.active ? this.productsInCatalog : null,
         variant: 'info',
         icon: 'redeem',
         reverseColors: false,
-        ...(!!this.productsInCatalog && {
+        ...(this.active && this.productsInCatalog && {
           link: {
             href: this.$store.state.app.links.coreProductsPageUrl,
             target: '_blank',
@@ -146,7 +146,7 @@ export default defineComponent({
       {
         title: this.$t('catalog.summaryPage.productCatalog.productVerification.reportCards.verified'),
         description: this.$t('catalog.summaryPage.productCatalog.productVerification.reportCards.verifiedDescription'),
-        value: this.verificationsStats.syncable,
+        value: this.active ? this.verificationsStats.syncable : null,
         variant: 'success',
         icon: 'send',
         reverseColors: false,
@@ -154,11 +154,11 @@ export default defineComponent({
       {
         title: this.$t('catalog.summaryPage.productCatalog.productVerification.reportCards.nonCompliant'),
         description: this.$t('catalog.summaryPage.productCatalog.productVerification.reportCards.nonCompliantDescription'),
-        value: this.verificationsStats.notSyncable,
+        value: this.active ? this.verificationsStats.notSyncable : null,
         variant: 'danger',
         icon: 'remove_shopping_cart',
         reverseColors: false,
-        ...(!!this.verificationsStats.notSyncable && {
+        ...(this.active && this.verificationsStats.notSyncable && {
           link: {
             to: {name: CatalogTabPages.prevalidationDetails},
           },

--- a/_dev/src/store/modules/catalog/mutations-types.ts
+++ b/_dev/src/store/modules/catalog/mutations-types.ts
@@ -5,6 +5,8 @@ enum MutationsTypes {
   SET_CATEGORY_MATCHING_SUMMARY = 'SET_CATEGORY_MATCHING_SUMMARY',
 
   SET_REQUEST_STATE = 'SET_REQUEST_STATE',
+
+  RESET = 'RESET',
 }
 
 export {MutationsTypes as default};

--- a/_dev/src/store/modules/catalog/mutations.ts
+++ b/_dev/src/store/modules/catalog/mutations.ts
@@ -39,4 +39,11 @@ export default {
   ) {
     state.requests[payload.request] = payload.newState;
   },
+
+  [MutationsTypes.RESET](
+    state: LocalState,
+  ) {
+    state.warmedUp = RequestState.IDLE;
+    state.enabledFeature = false;
+  },
 };

--- a/_dev/src/views/configuration.vue
+++ b/_dev/src/views/configuration.vue
@@ -476,6 +476,7 @@ export default defineComponent({
           ]);
           this.psFacebookJustOnboarded = false;
           this.loading = false;
+          this.$store.commit('catalog/RESET');
         }).catch((error) => {
           console.error(error);
           this.setErrorsFromFbCall(error);


### PR DESCRIPTION
- Reset data on GB logout
- Make sure dashes are shown on verified steps when sync has not been enabled for the first time