### PR TITLE
Fix build path

### DIFF
--- a/_dev/vite.config.ts
+++ b/_dev/vite.config.ts
@@ -41,7 +41,7 @@ export default defineConfig(({ mode }) => ({
     'process.env.NODE_ENV': mode === 'production' ? '"production"' : '"development"',
   },
   build: {
-    outDir: '../../../views/',
+    outDir: '../views/',
     publicPath: process.env.VITE_ASSETS_URL || '../modules/ps_facebook/views/',
     emptyOutDir: false,
     rollupOptions: {


### PR DESCRIPTION
The vite configuration file was taken from psxmarketingwithgoogle repository, where the development files are stored in `_dev/apps/ui`. Because PS Social is built in `_dev`, we do not need to go this far in parent directories.