### PR TITLE
Remove resubscribe button

### DIFF
--- a/_dev/.storybook/mock/ps-billing.ts
+++ b/_dev/.storybook/mock/ps-billing.ts
@@ -160,3 +160,19 @@ export const runningSubscription = {
   trial_end: 1698706800,
   is_free_trial_used: true,
 };
+
+
+export const makeSubscriptionFromEdition = (subscription) => {
+  return {
+    ...subscription,
+    parent_plan_name: "PrestaShop",
+    parent_product_id: "smb_edition",
+    plan_amount: 2900,
+    plan_unit_price: 2900,
+    subscription_items: [{
+      group_id: "smb_edition-growth",
+      item_price_id: "ps_facebook-standard-EUR-Monthly",
+      item_type: "plan",
+    }],
+  };
+};

--- a/_dev/src/components/configuration/alert-subscription-cancelled.vue
+++ b/_dev/src/components/configuration/alert-subscription-cancelled.vue
@@ -24,7 +24,10 @@
           }}
         </span>
       </p>
-      <div class="d-md-flex flex-grow-1 text-center align-items-end mt-2">
+      <div
+        class="d-md-flex flex-grow-1 text-center align-items-end mt-2"
+        v-if="isResubscriptionPossible"
+      >
         <b-button
           class="mx-1 mt-3 mt-md-0 mr-md-1 text-nowrap ml-auto"
           variant="outline-primary"
@@ -58,6 +61,9 @@ export default defineComponent({
         window.i18nSettings.languageLocale.substring(0, 2),
         {dateStyle: 'long'},
       );
+    },
+    isResubscriptionPossible(): boolean {
+      return !this.subscription.parent_plan_name;
     },
   },
 });

--- a/_dev/src/components/configuration/onboarding-deps-container.vue
+++ b/_dev/src/components/configuration/onboarding-deps-container.vue
@@ -91,7 +91,7 @@ export default defineComponent({
     };
   },
   computed: {
-    billingContext(): IContextBase<IContextAuthentication>|undefined {
+    billingContext(): {context: IContextBase<IContextAuthentication>}|undefined {
       return window.psBillingContext;
     },
     billingSubscription(): ISubscription|undefined {

--- a/_dev/src/shims-tsx.d.ts
+++ b/_dev/src/shims-tsx.d.ts
@@ -24,7 +24,7 @@ declare global {
       contextPsAccounts: any;
       psAccountShopId: string|null;
       contextPsEventbus: any;
-      psBillingContext?: IContextBase<IContextAuthentication>;
+      psBillingContext?: {context: IContextBase<IContextAuthentication>};
       psBillingSubscription?: ISubscription;
       psBilling: unknown;
       i18nSettings: any;

--- a/_dev/stories/109-configuration-suscription-cancelled.stories.ts
+++ b/_dev/stories/109-configuration-suscription-cancelled.stories.ts
@@ -1,5 +1,5 @@
 import AlertSubscriptionCancelled from '@/components/configuration/alert-subscription-cancelled.vue';
-import {trialEndedSubscription, trialNotRenewedSubscription} from '@/../.storybook/mock/ps-billing';
+import {trialEndedSubscription, trialNotRenewedSubscription, makeSubscriptionFromEdition} from '@/../.storybook/mock/ps-billing';
 
 export default {
   title: "Configuration/Billing/Alerts",
@@ -16,6 +16,7 @@ const Template = (args: any, { argTypes }: any) => ({
     />
   `,
 });
+
 export const SubscriptionNotRenewed: any = Template.bind({});
 SubscriptionNotRenewed.args = {
   billingSubscription: trialNotRenewedSubscription,
@@ -24,4 +25,14 @@ SubscriptionNotRenewed.args = {
 export const SubscriptionEnded: any = Template.bind({});
 SubscriptionEnded.args = {
   billingSubscription: trialEndedSubscription,
+};
+
+export const EditionSubscriptionNotRenewed: any = Template.bind({});
+EditionSubscriptionNotRenewed.args = {
+  billingSubscription: makeSubscriptionFromEdition(trialNotRenewedSubscription),
+};
+
+export const EditionSubscriptionEnded: any = Template.bind({});
+EditionSubscriptionEnded.args = {
+  billingSubscription: makeSubscriptionFromEdition(trialEndedSubscription),
 };


### PR DESCRIPTION
Edition subscriptions cannot be restarted from our module, so we remove the "Re-subscribe" button from our alerts.

![image](https://github.com/PrestaShopCorp/ps_facebook/assets/6768917/a9c3f28e-df52-41e5-934b-018fdd0ee79b)
