### PR TITLE
Fix display of dates in products sync report

### DIFF
--- a/_dev/src/components/catalog/report-details.vue
+++ b/_dev/src/components/catalog/report-details.vue
@@ -57,8 +57,14 @@
           class="text-muted text-italic"
         >
           {{ $t('syncReport.lastSyncDate', [
-            lastSyncDate.toLocaleDateString(undefined, { dateStyle: 'medium' }),
-            lastSyncDate.toLocaleTimeString(undefined),
+            lastSyncDate.toLocaleDateString(
+              $i18n.locale,
+              {dateStyle: 'long'},
+            ),
+            lastSyncDate.toLocaleTimeString(
+              $i18n.locale,
+              {hour: '2-digit', minute: '2-digit'},
+            ),
           ]) }}
         </span>
         <br v-if="lastSyncDate">

--- a/_dev/src/components/catalog/summary/panel/submitted-products.vue
+++ b/_dev/src/components/catalog/summary/panel/submitted-products.vue
@@ -139,7 +139,7 @@ export default defineComponent({
           {dateStyle: 'long'},
         ),
         time: this.validationSummary.lastSyncDate.toLocaleTimeString(
-          undefined,
+          this.$i18n.locale,
           {hour: '2-digit', minute: '2-digit'},
         ),
       });

--- a/_dev/src/components/catalog/summary/panel/submitted-products.vue
+++ b/_dev/src/components/catalog/summary/panel/submitted-products.vue
@@ -135,7 +135,7 @@ export default defineComponent({
 
       return this.$t('catalog.summaryPage.productCatalog.productsSentToFacebook.syncStatus.lastSyncDate', {
         date: this.validationSummary.lastSyncDate.toLocaleDateString(
-          window.i18nSettings.languageLocale.substring(0, 2),
+          this.$i18n.locale,
           {dateStyle: 'long'},
         ),
         time: this.validationSummary.lastSyncDate.toLocaleTimeString(

--- a/_dev/src/components/catalog/summary/panel/verified-products.vue
+++ b/_dev/src/components/catalog/summary/panel/verified-products.vue
@@ -128,7 +128,7 @@ export default defineComponent({
           {dateStyle: 'long'},
         ),
         time: this.verificationsStats.lastScanDate.toLocaleTimeString(
-          undefined,
+          this.$i18n.locale,
           {hour: '2-digit', minute: '2-digit'},
         ),
       });

--- a/_dev/src/components/catalog/summary/panel/verified-products.vue
+++ b/_dev/src/components/catalog/summary/panel/verified-products.vue
@@ -124,7 +124,7 @@ export default defineComponent({
 
       return this.$t('catalog.summaryPage.productCatalog.productVerification.scanStatus.lastScanDate', {
         date: this.verificationsStats.lastScanDate.toLocaleDateString(
-          window.i18nSettings.languageLocale.substring(0, 2),
+          this.$i18n.locale,
           {dateStyle: 'long'},
         ),
         time: this.verificationsStats.lastScanDate.toLocaleTimeString(

--- a/_dev/src/components/configuration/alert-subscription-cancelled.vue
+++ b/_dev/src/components/configuration/alert-subscription-cancelled.vue
@@ -58,7 +58,7 @@ export default defineComponent({
     },
     endOfSubscriptionDate(): string {
       return new Date(this.subscription.cancelled_at * 1000).toLocaleDateString(
-        window.i18nSettings.languageLocale.substring(0, 2),
+        this.$i18n.locale,
         {dateStyle: 'long'},
       );
     },

--- a/_dev/src/components/configuration/card-billing-connected.vue
+++ b/_dev/src/components/configuration/card-billing-connected.vue
@@ -46,13 +46,13 @@ export default defineComponent({
   computed: {
     nextBillingDate(): string {
       return new Date(this.subscription.next_billing_at * 1000).toLocaleDateString(
-        window.i18nSettings.languageLocale.substring(0, 2),
+        this.$i18n.locale,
         {dateStyle: 'long'},
       );
     },
     endOfSubscriptionDate(): string {
       return new Date(this.subscription.cancelled_at * 1000).toLocaleDateString(
-        window.i18nSettings.languageLocale.substring(0, 2),
+        this.$i18n.locale,
         {dateStyle: 'long'},
       );
     },

--- a/_dev/stories/231-catalog-report-details.stories.ts
+++ b/_dev/stories/231-catalog-report-details.stories.ts
@@ -91,7 +91,8 @@ const reporting = {
 const Template = (args: any, {argTypes}: any) => ({
   props: Object.keys(argTypes),
   components: {ReportDetails},
-  template: '<report-details :forceView="forceView" :forcePrevalidationRows="forcePrevalidationRows" :forceReportingRows="forceReportingRows" />',
+  template: '<report-details ref="page" :forceView="forceView" :forcePrevalidationRows="forcePrevalidationRows" :forceReportingRows="forceReportingRows" />',
+  mounted: args.mounted,
 });
 
 export const PrevalidationErrors: any = Template.bind({});
@@ -99,6 +100,9 @@ PrevalidationErrors.args = {
   forceView: 'PREVALIDATION',
   forcePrevalidationRows: [prevalidation15, prevalidation16a, prevalidation16bEn, prevalidation16bFr],
   forceReportingRows: reporting,
+  mounted: function(this: any) {
+    this.$refs.page.$data.lastSyncDate = new Date('2030-02-04 13:37');
+  },
 };
 
 export const NoPrevalidationError: any = Template.bind({});
@@ -106,6 +110,9 @@ NoPrevalidationError.args = {
   forceView: 'PREVALIDATION',
   forcePrevalidationRows: [],
   forceReportingRows: reporting,
+  mounted: function(this: any) {
+    this.$refs.page.$data.lastSyncDate = new Date('2030-02-04 13:37');
+  },
 };
 
 export const Reporting: any = Template.bind({});
@@ -113,6 +120,9 @@ Reporting.args = {
   forceView: 'REPORTING',
   forcePrevalidationRows: [prevalidation15],
   forceReportingRows: reporting,
+  mounted: function(this: any) {
+    this.$refs.page.$data.lastSyncDate = new Date('2030-02-04 13:37');
+  },
 };
 
 export const EmptyReporting: any = Template.bind({});
@@ -120,6 +130,9 @@ EmptyReporting.args = {
   forceView: 'REPORTING',
   forcePrevalidationRows: [prevalidation15],
   forceReportingRows: {},
+  mounted: function(this: any) {
+    this.$refs.page.$data.lastSyncDate = new Date('2030-02-04 13:37');
+  },
 };
 
 export const NoReportingAvailable: any = Template.bind({});
@@ -127,4 +140,7 @@ NoReportingAvailable.args = {
   forceView: 'PREVALIDATION',
   forcePrevalidationRows: [prevalidation15],
   forceReportingRows: null,
+  mounted: function(this: any) {
+    this.$refs.page.$data.lastSyncDate = new Date('2030-02-04 13:37');
+  },
 };


### PR DESCRIPTION
![Capture d’écran du 2024-02-22 20-51-07](https://github.com/PrestaShopCorp/ps_facebook/assets/6768917/1fb5f7c2-6d52-47e0-a9a9-b1a559d641ee)
![Capture d’écran du 2024-02-22 20-51-02](https://github.com/PrestaShopCorp/ps_facebook/assets/6768917/e3499869-7d11-4420-a5a8-707359ac3f6d)
![Capture d’écran du 2024-02-22 20-50-56](https://github.com/PrestaShopCorp/ps_facebook/assets/6768917/23e053ce-a775-423a-9396-f6d090036644)

* Improve use of locale to make the display of dates reactive on Storybook
* Fix related story
* Fix similar issue with times displayed all around the application. They were following the browser settings instead of the back office language